### PR TITLE
feat: add dynamic blocks

### DIFF
--- a/src/eval/for_each.rs
+++ b/src/eval/for_each.rs
@@ -63,6 +63,7 @@ mod tests {
     use super::*;
 
     // Mock implementation for testing
+    #[allow(dead_code)]
     struct MockResource;
 
     impl ForEachSupport for MockResource {


### PR DESCRIPTION
## Summary
- support Terraform-style dynamic blocks by expanding them before parsing
- handle nested `each` traversals for dynamic expressions
- test dynamic column generation with a dynamic block
- document dynamic block usage in README

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b69c5cd6808331b16ba11513579e4c