### PR TITLE
refactor: share ResourceKind enum with CLI

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
@@ -62,7 +63,7 @@ pub struct Config {
 }
 
 /// Resource types that can be filtered
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, ValueEnum)]
 pub enum ResourceKind {
     Schemas,
     Enums,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,9 @@
 use anyhow::{anyhow, Context, Result};
-use clap::{Parser, Subcommand, ValueEnum};
+use clap::{Parser, Subcommand};
 use dbschema::test_runner::TestBackend;
 use dbschema::{
     apply_filters,
-    config::{self, Config as DbschemaConfig, TargetConfig},
+    config::{self, Config as DbschemaConfig, ResourceKind, TargetConfig},
     load_config, validate, EnvVars, Loader,
 };
 use std::collections::HashMap;
@@ -76,20 +76,6 @@ enum Commands {
         #[arg(long = "name")]
         names: Vec<String>,
     },
-}
-
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, ValueEnum)]
-enum ResourceKind {
-    Schemas,
-    Enums,
-    Tables,
-    Views,
-    Materialized,
-    Functions,
-    Triggers,
-    Extensions,
-    Policies,
-    Tests,
 }
 
 fn main() -> Result<()> {


### PR DESCRIPTION
## Summary
- expose `config::ResourceKind` for CLI
- remove duplicate `ResourceKind` definition in `main.rs`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b6b09716b483319ea2ab705f343800