### PR TITLE
Add logging with env_logger

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ md5 = "0.8"
 walkdir = "2"
 path-absolutize = "3"
 postgres = "0.19"
+log = "0.4"
+env_logger = "0.11"
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -46,6 +46,17 @@ cargo build --release
 - Variables: `--var schema=public` or `--var-file .env.hcl`
 - Using config file: `dbschema --config` or `dbschema --config --target <target_name>`
 
+## Logging
+
+This project uses [`env_logger`](https://docs.rs/env_logger) with `info` output enabled by default.
+Set the `RUST_LOG` environment variable to control verbosity:
+
+```bash
+RUST_LOG=debug dbschema --input examples/main.hcl validate
+```
+
+Use `warn` or `error` to reduce output, e.g. `RUST_LOG=warn`.
+
 ## Configuration File
 
 dbschema can be configured using a `dbschema.toml` file in the root of your project. This file allows you to define multiple generation targets, each with its own settings.


### PR DESCRIPTION
## Summary
- add log and env_logger dependencies
- replace println! diagnostics with info!/error! macros
- initialize env_logger and document RUST_LOG for verbosity control

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b6bb4fcee08331a7e16f03836226cb