### PR TITLE
Add collection, conversion and datetime helpers

### DIFF
--- a/src/eval/builtins/collection.rs
+++ b/src/eval/builtins/collection.rs
@@ -1,15 +1,268 @@
-// Collection/array functions - to be implemented
-// Future functions:
-// - concat(array1, array2, ...)
-// - flatten(array)
-// - distinct(array)
-// - slice(array, start, end)
-// - sort(array)
-// - reverse(array)
-// - index(array, value)
-// - length(array) - already exists for strings
+use hcl::eval::{FuncArgs, FuncDef, ParamType};
+use hcl::Value;
+
+/// Concatenate multiple arrays into a single array
+pub fn create_concat_func() -> FuncDef {
+    FuncDef::builder()
+        .param(ParamType::array_of(ParamType::Any))
+        .variadic_param(ParamType::array_of(ParamType::Any))
+        .build(|args: FuncArgs| {
+            let mut result: Vec<Value> = Vec::new();
+            for arg in args.iter() {
+                let arr = arg.as_array().unwrap();
+                result.extend(arr.clone());
+            }
+            Ok(Value::from(result))
+        })
+}
+
+/// Flatten a nested array into a single level array
+pub fn create_flatten_func() -> FuncDef {
+    FuncDef::builder()
+        .param(ParamType::array_of(ParamType::Any))
+        .build(|args: FuncArgs| {
+            fn flatten(values: &Vec<Value>, out: &mut Vec<Value>) {
+                for v in values {
+                    if let Some(arr) = v.as_array() {
+                        flatten(arr, out);
+                    } else {
+                        out.push(v.clone());
+                    }
+                }
+            }
+
+            let arr = args[0].as_array().unwrap();
+            let mut result = Vec::new();
+            flatten(arr, &mut result);
+            Ok(Value::from(result))
+        })
+}
+
+/// Remove duplicate values from an array preserving the first occurrence
+pub fn create_distinct_func() -> FuncDef {
+    FuncDef::builder()
+        .param(ParamType::array_of(ParamType::Any))
+        .build(|args: FuncArgs| {
+            let arr = args[0].as_array().unwrap();
+            let mut result: Vec<Value> = Vec::new();
+            for v in arr.iter() {
+                if !result.contains(v) {
+                    result.push(v.clone());
+                }
+            }
+            Ok(Value::from(result))
+        })
+}
+
+/// Return a slice of the array from start (inclusive) to end (exclusive)
+pub fn create_slice_func() -> FuncDef {
+    FuncDef::builder()
+        .param(ParamType::array_of(ParamType::Any))
+        .param(ParamType::Number)
+        .param(ParamType::Number)
+        .build(|args: FuncArgs| {
+            let arr = args[0].as_array().unwrap();
+            let len = arr.len() as i64;
+            let mut start = args[1].as_i64().unwrap();
+            let mut end = args[2].as_i64().unwrap();
+
+            if start < 0 {
+                start = len + start;
+            }
+            if end < 0 {
+                end = len + end;
+            }
+
+            if start < 0 || end < 0 || start > len || end > len || start >= end {
+                return Ok(Value::from(Vec::<Value>::new()));
+            }
+
+            let slice: Vec<Value> = arr[start as usize..end as usize].to_vec();
+            Ok(Value::from(slice))
+        })
+}
+
+/// Sort an array of strings or numbers
+pub fn create_sort_func() -> FuncDef {
+    FuncDef::builder()
+        .param(ParamType::array_of(ParamType::Any))
+        .build(|args: FuncArgs| {
+            let arr = args[0].as_array().unwrap();
+            let mut result = arr.clone();
+            result.sort_by(|a, b| {
+                if let (Some(sa), Some(sb)) = (a.as_str(), b.as_str()) {
+                    sa.cmp(sb)
+                } else if let (Some(na), Some(nb)) = (a.as_i64(), b.as_i64()) {
+                    na.cmp(&nb)
+                } else {
+                    a.to_string().cmp(&b.to_string())
+                }
+            });
+            Ok(Value::from(result))
+        })
+}
+
+/// Reverse the order of elements in an array
+pub fn create_reverse_func() -> FuncDef {
+    FuncDef::builder()
+        .param(ParamType::array_of(ParamType::Any))
+        .build(|args: FuncArgs| {
+            let arr = args[0].as_array().unwrap();
+            let result: Vec<Value> = arr.iter().cloned().rev().collect();
+            Ok(Value::from(result))
+        })
+}
+
+/// Return the index of a value in an array, or error if not found
+pub fn create_index_func() -> FuncDef {
+    FuncDef::builder()
+        .param(ParamType::array_of(ParamType::Any))
+        .param(ParamType::Any)
+        .build(|args: FuncArgs| {
+            let arr = args[0].as_array().unwrap();
+            let value = &args[1];
+            if let Some(pos) = arr.iter().position(|v| v == value) {
+                Ok(Value::from(pos as i64))
+            } else {
+                Err("value not found".to_string())
+            }
+        })
+}
 
 #[cfg(test)]
 mod tests {
-    // Tests will be added when functions are implemented
+    use super::*;
+    use hcl::eval::{Context, Evaluate};
+
+    fn create_test_context() -> Context<'static> {
+        let mut ctx = Context::new();
+        ctx.declare_func("concat", create_concat_func());
+        ctx.declare_func("flatten", create_flatten_func());
+        ctx.declare_func("distinct", create_distinct_func());
+        ctx.declare_func("slice", create_slice_func());
+        ctx.declare_func("sort", create_sort_func());
+        ctx.declare_func("reverse", create_reverse_func());
+        ctx.declare_func("index", create_index_func());
+        ctx
+    }
+
+    #[test]
+    fn test_concat_function() {
+        let ctx = create_test_context();
+        let expr_str = "concat([1,2], [3])";
+        let body: hcl::Body = hcl::from_str(&format!("test = {}", expr_str)).unwrap();
+        let expr = body
+            .attributes()
+            .find(|a| a.key() == "test")
+            .unwrap()
+            .expr();
+        let expected = Value::from(vec![Value::from(1), Value::from(2), Value::from(3)]);
+        assert_eq!(expr.evaluate(&ctx).unwrap(), expected);
+    }
+
+    #[test]
+    fn test_flatten_function() {
+        let ctx = create_test_context();
+        let expr_str = "flatten([[1,2],[3,4]])";
+        let body: hcl::Body = hcl::from_str(&format!("test = {}", expr_str)).unwrap();
+        let expr = body
+            .attributes()
+            .find(|a| a.key() == "test")
+            .unwrap()
+            .expr();
+        let expected = Value::from(
+            vec![1, 2, 3, 4]
+                .into_iter()
+                .map(Value::from)
+                .collect::<Vec<_>>(),
+        );
+        assert_eq!(expr.evaluate(&ctx).unwrap(), expected);
+    }
+
+    #[test]
+    fn test_distinct_function() {
+        let ctx = create_test_context();
+        let expr_str = "distinct([1,2,2,3])";
+        let body: hcl::Body = hcl::from_str(&format!("test = {}", expr_str)).unwrap();
+        let expr = body
+            .attributes()
+            .find(|a| a.key() == "test")
+            .unwrap()
+            .expr();
+        let expected = Value::from(
+            vec![1, 2, 3]
+                .into_iter()
+                .map(Value::from)
+                .collect::<Vec<_>>(),
+        );
+        assert_eq!(expr.evaluate(&ctx).unwrap(), expected);
+    }
+
+    #[test]
+    fn test_slice_function() {
+        let ctx = create_test_context();
+        let expr_str = "slice([1,2,3,4,5], 1, 3)";
+        let body: hcl::Body = hcl::from_str(&format!("test = {}", expr_str)).unwrap();
+        let expr = body
+            .attributes()
+            .find(|a| a.key() == "test")
+            .unwrap()
+            .expr();
+        let expected = Value::from(vec![Value::from(2), Value::from(3)]);
+        assert_eq!(expr.evaluate(&ctx).unwrap(), expected);
+    }
+
+    #[test]
+    fn test_sort_function() {
+        let ctx = create_test_context();
+        let expr_str = "sort([\"b\", \"a\", \"c\"])";
+        let body: hcl::Body = hcl::from_str(&format!("test = {}", expr_str)).unwrap();
+        let expr = body
+            .attributes()
+            .find(|a| a.key() == "test")
+            .unwrap()
+            .expr();
+        let expected = Value::from(vec![Value::from("a"), Value::from("b"), Value::from("c")]);
+        assert_eq!(expr.evaluate(&ctx).unwrap(), expected);
+    }
+
+    #[test]
+    fn test_reverse_function() {
+        let ctx = create_test_context();
+        let expr_str = "reverse([1,2,3])";
+        let body: hcl::Body = hcl::from_str(&format!("test = {}", expr_str)).unwrap();
+        let expr = body
+            .attributes()
+            .find(|a| a.key() == "test")
+            .unwrap()
+            .expr();
+        let expected = Value::from(vec![Value::from(3), Value::from(2), Value::from(1)]);
+        assert_eq!(expr.evaluate(&ctx).unwrap(), expected);
+    }
+
+    #[test]
+    fn test_index_function_success() {
+        let ctx = create_test_context();
+        let expr_str = "index([1,2,3], 2)";
+        let body: hcl::Body = hcl::from_str(&format!("test = {}", expr_str)).unwrap();
+        let expr = body
+            .attributes()
+            .find(|a| a.key() == "test")
+            .unwrap()
+            .expr();
+        assert_eq!(expr.evaluate(&ctx).unwrap(), Value::from(1));
+    }
+
+    #[test]
+    fn test_index_function_error() {
+        let ctx = create_test_context();
+        let expr_str = "index([1,2,3], 5)";
+        let body: hcl::Body = hcl::from_str(&format!("test = {}", expr_str)).unwrap();
+        let expr = body
+            .attributes()
+            .find(|a| a.key() == "test")
+            .unwrap()
+            .expr();
+        assert!(expr.evaluate(&ctx).is_err());
+    }
 }

--- a/src/eval/builtins/conversion.rs
+++ b/src/eval/builtins/conversion.rs
@@ -1,12 +1,201 @@
-// Type conversion functions - to be implemented
-// Future functions:
-// - tostring(value)
-// - tonumber(value)
-// - tobool(value)
-// - tolist(value)
-// - tomap(value)
+use hcl::eval::{FuncArgs, FuncDef, ParamType};
+use hcl::Value;
+
+/// Convert a value to a string
+pub fn create_tostring_func() -> FuncDef {
+    FuncDef::builder()
+        .param(ParamType::Any)
+        .build(|args: FuncArgs| Ok(Value::from(args[0].to_string())))
+}
+
+/// Convert a value to a number
+pub fn create_tonumber_func() -> FuncDef {
+    FuncDef::builder()
+        .param(ParamType::Any)
+        .build(|args: FuncArgs| {
+            let v = &args[0];
+            if let Some(n) = v.as_i64() {
+                Ok(Value::from(n))
+            } else if let Some(s) = v.as_str() {
+                s.parse::<i64>()
+                    .map(Value::from)
+                    .map_err(|_| "invalid number".to_string())
+            } else if let Some(b) = v.as_bool() {
+                Ok(Value::from(if b { 1 } else { 0 }))
+            } else {
+                Err("cannot convert to number".to_string())
+            }
+        })
+}
+
+/// Convert a value to a boolean
+pub fn create_tobool_func() -> FuncDef {
+    FuncDef::builder()
+        .param(ParamType::Any)
+        .build(|args: FuncArgs| {
+            let v = &args[0];
+            if let Some(b) = v.as_bool() {
+                Ok(Value::from(b))
+            } else if let Some(s) = v.as_str() {
+                match s.parse::<bool>() {
+                    Ok(b) => Ok(Value::from(b)),
+                    Err(_) => Err("invalid bool".to_string()),
+                }
+            } else if let Some(n) = v.as_i64() {
+                Ok(Value::from(n != 0))
+            } else {
+                Err("cannot convert to bool".to_string())
+            }
+        })
+}
+
+/// Convert a value to a list
+pub fn create_tolist_func() -> FuncDef {
+    FuncDef::builder()
+        .param(ParamType::Any)
+        .build(|args: FuncArgs| {
+            let v = &args[0];
+            if let Some(arr) = v.as_array() {
+                Ok(Value::from(arr.clone()))
+            } else {
+                Ok(Value::from(vec![v.clone()]))
+            }
+        })
+}
+
+/// Convert a value to a map
+pub fn create_tomap_func() -> FuncDef {
+    FuncDef::builder()
+        .param(ParamType::Any)
+        .build(|args: FuncArgs| {
+            let v = &args[0];
+            if let Some(obj) = v.as_object() {
+                Ok(Value::from(obj.clone()))
+            } else {
+                Err("cannot convert to map".to_string())
+            }
+        })
+}
 
 #[cfg(test)]
 mod tests {
-    // Tests will be added when functions are implemented
+    use super::*;
+    use hcl::eval::{Context, Evaluate};
+
+    fn create_test_context() -> Context<'static> {
+        let mut ctx = Context::new();
+        ctx.declare_func("tostring", create_tostring_func());
+        ctx.declare_func("tonumber", create_tonumber_func());
+        ctx.declare_func("tobool", create_tobool_func());
+        ctx.declare_func("tolist", create_tolist_func());
+        ctx.declare_func("tomap", create_tomap_func());
+        ctx
+    }
+
+    #[test]
+    fn test_tostring_function() {
+        let ctx = create_test_context();
+        let expr_str = "tostring(123)";
+        let body: hcl::Body = hcl::from_str(&format!("test = {}", expr_str)).unwrap();
+        let expr = body
+            .attributes()
+            .find(|a| a.key() == "test")
+            .unwrap()
+            .expr();
+        assert_eq!(expr.evaluate(&ctx).unwrap(), Value::from("123"));
+    }
+
+    #[test]
+    fn test_tonumber_function() {
+        let ctx = create_test_context();
+        let expr_str = "tonumber(\"123\")";
+        let body: hcl::Body = hcl::from_str(&format!("test = {}", expr_str)).unwrap();
+        let expr = body
+            .attributes()
+            .find(|a| a.key() == "test")
+            .unwrap()
+            .expr();
+        assert_eq!(expr.evaluate(&ctx).unwrap(), Value::from(123));
+    }
+
+    #[test]
+    fn test_tonumber_error() {
+        let ctx = create_test_context();
+        let expr_str = "tonumber(\"abc\")";
+        let body: hcl::Body = hcl::from_str(&format!("test = {}", expr_str)).unwrap();
+        let expr = body
+            .attributes()
+            .find(|a| a.key() == "test")
+            .unwrap()
+            .expr();
+        assert!(expr.evaluate(&ctx).is_err());
+    }
+
+    #[test]
+    fn test_tobool_function() {
+        let ctx = create_test_context();
+        let expr_str = "tobool(\"true\")";
+        let body: hcl::Body = hcl::from_str(&format!("test = {}", expr_str)).unwrap();
+        let expr = body
+            .attributes()
+            .find(|a| a.key() == "test")
+            .unwrap()
+            .expr();
+        assert_eq!(expr.evaluate(&ctx).unwrap(), Value::from(true));
+    }
+
+    #[test]
+    fn test_tobool_error() {
+        let ctx = create_test_context();
+        let expr_str = "tobool(\"maybe\")";
+        let body: hcl::Body = hcl::from_str(&format!("test = {}", expr_str)).unwrap();
+        let expr = body
+            .attributes()
+            .find(|a| a.key() == "test")
+            .unwrap()
+            .expr();
+        assert!(expr.evaluate(&ctx).is_err());
+    }
+
+    #[test]
+    fn test_tolist_function() {
+        let ctx = create_test_context();
+        let expr_str = "tolist(1)";
+        let body: hcl::Body = hcl::from_str(&format!("test = {}", expr_str)).unwrap();
+        let expr = body
+            .attributes()
+            .find(|a| a.key() == "test")
+            .unwrap()
+            .expr();
+        let expected = Value::from(vec![Value::from(1)]);
+        assert_eq!(expr.evaluate(&ctx).unwrap(), expected);
+    }
+
+    #[test]
+    fn test_tomap_function() {
+        let ctx = create_test_context();
+        let expr_str = "tomap({a = 1})";
+        let body: hcl::Body = hcl::from_str(&format!("test = {}", expr_str)).unwrap();
+        let expr = body
+            .attributes()
+            .find(|a| a.key() == "test")
+            .unwrap()
+            .expr();
+        let mut map = hcl::value::Map::new();
+        map.insert("a".to_string(), Value::from(1));
+        assert_eq!(expr.evaluate(&ctx).unwrap(), Value::from(map));
+    }
+
+    #[test]
+    fn test_tomap_error() {
+        let ctx = create_test_context();
+        let expr_str = "tomap([1,2])";
+        let body: hcl::Body = hcl::from_str(&format!("test = {}", expr_str)).unwrap();
+        let expr = body
+            .attributes()
+            .find(|a| a.key() == "test")
+            .unwrap()
+            .expr();
+        assert!(expr.evaluate(&ctx).is_err());
+    }
 }

--- a/src/eval/builtins/datetime.rs
+++ b/src/eval/builtins/datetime.rs
@@ -1,11 +1,171 @@
-// Date/time functions - to be implemented
-// Future functions:
-// - timestamp()
-// - formatdate(format, timestamp)
-// - timeadd(timestamp, duration)
-// - timecmp(timestamp1, timestamp2)
+use chrono::{DateTime, Duration, Utc};
+use hcl::eval::{FuncArgs, FuncDef, ParamType};
+use hcl::Value;
+
+/// Return the current timestamp in RFC3339 format
+pub fn create_timestamp_func() -> FuncDef {
+    FuncDef::builder().build(|_: FuncArgs| Ok(Value::from(Utc::now().to_rfc3339())))
+}
+
+/// Format a timestamp using the provided format string
+pub fn create_formatdate_func() -> FuncDef {
+    FuncDef::builder()
+        .param(ParamType::String)
+        .param(ParamType::String)
+        .build(|args: FuncArgs| {
+            let fmt = args[0].as_str().unwrap();
+            let ts = args[1].as_str().unwrap();
+            let dt = DateTime::parse_from_rfc3339(ts).map_err(|e| e.to_string())?;
+            Ok(Value::from(dt.format(fmt).to_string()))
+        })
+}
+
+/// Add a duration to a timestamp
+pub fn create_timeadd_func() -> FuncDef {
+    FuncDef::builder()
+        .param(ParamType::String)
+        .param(ParamType::String)
+        .build(|args: FuncArgs| {
+            let ts = args[0].as_str().unwrap();
+            let dur_str = args[1].as_str().unwrap();
+            let dt = DateTime::parse_from_rfc3339(ts)
+                .map_err(|e| e.to_string())?
+                .with_timezone(&Utc);
+
+            if dur_str.is_empty() {
+                return Err("invalid duration".to_string());
+            }
+
+            let (num_part, unit_part) = dur_str.split_at(dur_str.len() - 1);
+            let n: i64 = num_part
+                .parse()
+                .map_err(|_| "invalid duration".to_string())?;
+            let dur = match unit_part {
+                "s" => Duration::seconds(n),
+                "m" => Duration::minutes(n),
+                "h" => Duration::hours(n),
+                "d" => Duration::days(n),
+                _ => return Err("invalid duration".to_string()),
+            };
+
+            let new_dt = dt + dur;
+            Ok(Value::from(new_dt.to_rfc3339()))
+        })
+}
+
+/// Compare two timestamps returning -1, 0, or 1
+pub fn create_timecmp_func() -> FuncDef {
+    FuncDef::builder()
+        .param(ParamType::String)
+        .param(ParamType::String)
+        .build(|args: FuncArgs| {
+            let ts1 = DateTime::parse_from_rfc3339(args[0].as_str().unwrap())
+                .map_err(|e| e.to_string())?;
+            let ts2 = DateTime::parse_from_rfc3339(args[1].as_str().unwrap())
+                .map_err(|e| e.to_string())?;
+            let ord = ts1.cmp(&ts2);
+            let result = match ord {
+                std::cmp::Ordering::Less => -1,
+                std::cmp::Ordering::Equal => 0,
+                std::cmp::Ordering::Greater => 1,
+            };
+            Ok(Value::from(result))
+        })
+}
 
 #[cfg(test)]
 mod tests {
-    // Tests will be added when functions are implemented
+    use super::*;
+    use hcl::eval::{Context, Evaluate};
+
+    fn create_test_context() -> Context<'static> {
+        let mut ctx = Context::new();
+        ctx.declare_func("timestamp", create_timestamp_func());
+        ctx.declare_func("formatdate", create_formatdate_func());
+        ctx.declare_func("timeadd", create_timeadd_func());
+        ctx.declare_func("timecmp", create_timecmp_func());
+        ctx
+    }
+
+    #[test]
+    fn test_timestamp_function() {
+        let ctx = create_test_context();
+        let expr_str = "timestamp()";
+        let body: hcl::Body = hcl::from_str(&format!("test = {}", expr_str)).unwrap();
+        let expr = body
+            .attributes()
+            .find(|a| a.key() == "test")
+            .unwrap()
+            .expr();
+        let val = expr.evaluate(&ctx).unwrap();
+        assert!(DateTime::parse_from_rfc3339(val.as_str().unwrap()).is_ok());
+    }
+
+    #[test]
+    fn test_formatdate_function() {
+        let ctx = create_test_context();
+        let expr_str = "formatdate(\"%Y-%m-%d\", \"2020-01-01T00:00:00Z\")";
+        let body: hcl::Body = hcl::from_str(&format!("test = {}", expr_str)).unwrap();
+        let expr = body
+            .attributes()
+            .find(|a| a.key() == "test")
+            .unwrap()
+            .expr();
+        assert_eq!(expr.evaluate(&ctx).unwrap(), Value::from("2020-01-01"));
+    }
+
+    #[test]
+    fn test_formatdate_error() {
+        let ctx = create_test_context();
+        let expr_str = "formatdate(\"%Y\", \"invalid\")";
+        let body: hcl::Body = hcl::from_str(&format!("test = {}", expr_str)).unwrap();
+        let expr = body
+            .attributes()
+            .find(|a| a.key() == "test")
+            .unwrap()
+            .expr();
+        assert!(expr.evaluate(&ctx).is_err());
+    }
+
+    #[test]
+    fn test_timeadd_function() {
+        let ctx = create_test_context();
+        let expr_str = "timeadd(\"2020-01-01T00:00:00Z\", \"1h\")";
+        let body: hcl::Body = hcl::from_str(&format!("test = {}", expr_str)).unwrap();
+        let expr = body
+            .attributes()
+            .find(|a| a.key() == "test")
+            .unwrap()
+            .expr();
+        assert_eq!(
+            expr.evaluate(&ctx).unwrap(),
+            Value::from("2020-01-01T01:00:00+00:00")
+        );
+    }
+
+    #[test]
+    fn test_timeadd_error() {
+        let ctx = create_test_context();
+        let expr_str = "timeadd(\"2020-01-01T00:00:00Z\", \"10x\")";
+        let body: hcl::Body = hcl::from_str(&format!("test = {}", expr_str)).unwrap();
+        let expr = body
+            .attributes()
+            .find(|a| a.key() == "test")
+            .unwrap()
+            .expr();
+        assert!(expr.evaluate(&ctx).is_err());
+    }
+
+    #[test]
+    fn test_timecmp_function() {
+        let ctx = create_test_context();
+        let expr_str = "timecmp(\"2020-01-01T00:00:00Z\", \"2020-01-02T00:00:00Z\")";
+        let body: hcl::Body = hcl::from_str(&format!("test = {}", expr_str)).unwrap();
+        let expr = body
+            .attributes()
+            .find(|a| a.key() == "test")
+            .unwrap()
+            .expr();
+        assert_eq!(expr.evaluate(&ctx).unwrap(), Value::from(-1));
+    }
 }

--- a/src/eval/builtins/mod.rs
+++ b/src/eval/builtins/mod.rs
@@ -31,10 +31,26 @@ pub fn create_context() -> Context<'static> {
     ctx.declare_func("max", numeric::create_max_func());
     ctx.declare_func("abs", numeric::create_abs_func());
 
+    // Collection functions
+    ctx.declare_func("concat", collection::create_concat_func());
+    ctx.declare_func("flatten", collection::create_flatten_func());
+    ctx.declare_func("distinct", collection::create_distinct_func());
+    ctx.declare_func("slice", collection::create_slice_func());
+    ctx.declare_func("sort", collection::create_sort_func());
+    ctx.declare_func("reverse", collection::create_reverse_func());
+    ctx.declare_func("index", collection::create_index_func());
+
     // Utility functions
     ctx.declare_func("coalesce", utility::create_coalesce_func());
     ctx.declare_func("join", utility::create_join_func());
     ctx.declare_func("split", utility::create_split_func());
+
+    // Conversion functions
+    ctx.declare_func("tostring", conversion::create_tostring_func());
+    ctx.declare_func("tonumber", conversion::create_tonumber_func());
+    ctx.declare_func("tobool", conversion::create_tobool_func());
+    ctx.declare_func("tolist", conversion::create_tolist_func());
+    ctx.declare_func("tomap", conversion::create_tomap_func());
 
     // Cryptographic functions
     ctx.declare_func("md5", crypto::create_md5_func());
@@ -44,6 +60,12 @@ pub fn create_context() -> Context<'static> {
     // Base64 functions
     ctx.declare_func("base64encode", base64::create_base64encode_func());
     ctx.declare_func("base64decode", base64::create_base64decode_func());
+
+    // Datetime functions
+    ctx.declare_func("timestamp", datetime::create_timestamp_func());
+    ctx.declare_func("formatdate", datetime::create_formatdate_func());
+    ctx.declare_func("timeadd", datetime::create_timeadd_func());
+    ctx.declare_func("timecmp", datetime::create_timecmp_func());
 
     ctx
 }
@@ -71,14 +93,30 @@ mod tests {
             "min",
             "max",
             "abs",
+            "concat",
+            "flatten",
+            "distinct",
+            "slice",
+            "sort",
+            "reverse",
+            "index",
             "coalesce",
             "join",
             "split",
+            "tostring",
+            "tonumber",
+            "tobool",
+            "tolist",
+            "tomap",
             "md5",
             "sha256",
             "sha512",
             "base64encode",
             "base64decode",
+            "timestamp",
+            "formatdate",
+            "timeadd",
+            "timecmp",
         ];
 
         for func_name in functions {


### PR DESCRIPTION
## Summary
- implement array utilities like concat, flatten, distinct, slice, sort, reverse and index
- add type conversion helpers to/from strings, numbers, bools, lists and maps
- support timestamp utilities including formatting, adding durations and comparison

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b6c4afa1c083318eb0ddc7f803af79