### PR TITLE
Move EnvVars to frontend and simplify backend generation

### DIFF
--- a/src/backends/json.rs
+++ b/src/backends/json.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use serde_json::json;
 
 use super::Backend;
-use crate::ir::{Config, EnvVars};
+use crate::ir::Config;
 
 pub struct JsonBackend;
 
@@ -13,42 +13,11 @@ impl Backend for JsonBackend {
     fn file_extension(&self) -> &'static str {
         "json"
     }
-    fn generate(&self, cfg: &Config, env: &EnvVars, _strict: bool) -> Result<String> {
-        let mut vars_json = serde_json::Map::new();
-        for (k, v) in &env.vars {
-            vars_json.insert(k.clone(), hcl_to_json(v)?);
-        }
-
+    fn generate(&self, cfg: &Config, _strict: bool) -> Result<String> {
         let output = json!({
             "backend": self.name(),
             "config": cfg,
-            "vars": vars_json,
         });
         serde_json::to_string_pretty(&output).map_err(Into::into)
-    }
-}
-
-fn hcl_to_json(value: &hcl::Value) -> Result<serde_json::Value> {
-    match value {
-        hcl::Value::Null => Ok(serde_json::Value::Null),
-        hcl::Value::Bool(b) => Ok(serde_json::Value::Bool(*b)),
-        hcl::Value::Number(n) => Ok(serde_json::Value::Number(
-            serde_json::Number::from_f64(n.as_f64().unwrap()).unwrap(),
-        )),
-        hcl::Value::String(s) => Ok(serde_json::Value::String(s.clone())),
-        hcl::Value::Array(arr) => {
-            let mut values = Vec::new();
-            for v in arr {
-                values.push(hcl_to_json(v)?);
-            }
-            Ok(serde_json::Value::Array(values))
-        }
-        hcl::Value::Object(map) => {
-            let mut json_map = serde_json::Map::new();
-            for (k, v) in map {
-                json_map.insert(k.clone(), hcl_to_json(v)?);
-            }
-            Ok(serde_json::Value::Object(json_map))
-        }
     }
 }

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -9,7 +9,7 @@ pub mod prisma;
 pub trait Backend {
     fn name(&self) -> &'static str;
     fn file_extension(&self) -> &'static str;
-    fn generate(&self, cfg: &Config, env: &crate::ir::EnvVars, strict: bool) -> Result<String>;
+    fn generate(&self, cfg: &Config, strict: bool) -> Result<String>;
 }
 
 pub fn get_backend(name: &str) -> Option<Box<dyn Backend>> {

--- a/src/backends/postgres.rs
+++ b/src/backends/postgres.rs
@@ -25,12 +25,7 @@ impl Backend for PostgresBackend {
     fn file_extension(&self) -> &'static str {
         "sql"
     }
-    fn generate(
-        &self,
-        cfg: &Config,
-        _env: &crate::ir::EnvVars,
-        _strict: bool,
-    ) -> Result<String> {
+    fn generate(&self, cfg: &Config, _strict: bool) -> Result<String> {
         to_sql(cfg)
     }
 }

--- a/src/backends/prisma.rs
+++ b/src/backends/prisma.rs
@@ -13,7 +13,7 @@ impl Backend for PrismaBackend {
     fn file_extension(&self) -> &'static str {
         "prisma"
     }
-    fn generate(&self, cfg: &Config, _env: &crate::ir::EnvVars, strict: bool) -> Result<String> {
+    fn generate(&self, cfg: &Config, strict: bool) -> Result<String> {
         let mut out = String::new();
         // Output only enums and models; generator/datasource are managed externally.
 

--- a/src/frontend/core.rs
+++ b/src/frontend/core.rs
@@ -9,8 +9,9 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use crate::frontend::builtins;
+use crate::frontend::env::EnvVars;
 use crate::frontend::for_each::execute_for_each;
-use crate::ir::{Config, EnvVars};
+use crate::ir::Config;
 use crate::Loader;
 
 pub fn expr_to_string(expr: &hcl::Expression, env: &EnvVars) -> Result<String> {

--- a/src/frontend/env.rs
+++ b/src/frontend/env.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 ///
 /// # Example
 /// ```
-/// use dbschema::ir::EnvVars;
+/// use dbschema::frontend::env::EnvVars;
 /// use hcl::Value;
 /// use std::collections::HashMap;
 ///

--- a/src/frontend/for_each.rs
+++ b/src/frontend/for_each.rs
@@ -1,4 +1,5 @@
 use crate::frontend::core;
+use crate::frontend::env::EnvVars;
 use anyhow::{bail, Result};
 
 /// Trait for types that support for_each iteration
@@ -7,7 +8,7 @@ pub trait ForEachSupport {
     type Item;
 
     /// Parse a single item from the HCL block
-    fn parse_one(name: &str, body: &hcl::Body, env: &crate::ir::EnvVars) -> Result<Self::Item>;
+    fn parse_one(name: &str, body: &hcl::Body, env: &EnvVars) -> Result<Self::Item>;
 
     /// Add the parsed item to the configuration
     fn add_to_config(item: Self::Item, config: &mut crate::ir::Config);
@@ -17,7 +18,7 @@ pub trait ForEachSupport {
 pub fn execute_for_each<T: ForEachSupport>(
     name: &str,
     body: &hcl::Body,
-    env: &crate::ir::EnvVars,
+    env: &EnvVars,
     config: &mut crate::ir::Config,
     for_each_expr: Option<&hcl::Attribute>,
 ) -> Result<()> {
@@ -72,7 +73,7 @@ mod tests {
         fn parse_one(
             name: &str,
             _body: &hcl::Body,
-            env: &crate::ir::EnvVars,
+            env: &EnvVars,
         ) -> Result<Self::Item> {
             // Simple mock that returns the name with each.value if available
             if let Some((_key, value)) = &env.each {

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -1,5 +1,6 @@
 pub mod builtins;
 pub mod core;
+pub mod env;
 pub mod for_each;
 pub mod resource_impls;
 

--- a/src/frontend/resource_impls.rs
+++ b/src/frontend/resource_impls.rs
@@ -3,6 +3,7 @@ use hcl::Body;
 
 use crate::frontend::core::{expr_to_string_vec, find_attr, get_attr_bool, get_attr_string};
 use crate::frontend::for_each::ForEachSupport;
+use crate::frontend::env::EnvVars;
 use crate::ir::*;
 
 // Schema implementation

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -1,9 +1,7 @@
 pub mod config;
-pub mod env;
 
 pub use config::{
     BackReferenceSpec, ColumnSpec, Config, EnumSpec, ExtensionSpec, ForeignKeySpec,
     FunctionSpec, IndexSpec, MaterializedViewSpec, PolicySpec, PrimaryKeySpec, SchemaSpec,
     TableSpec, TestSpec, TriggerSpec, ViewSpec,
 };
-pub use env::EnvVars;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,9 @@ use dbschema::test_runner::TestBackend;
 use dbschema::{
     apply_filters,
     config::{self, Config as DbschemaConfig, ResourceKind, TargetConfig},
-    load_config, validate, EnvVars, Loader,
+    load_config, validate, Loader,
 };
+use dbschema::frontend::env::EnvVars;
 use log::{error, info};
 use std::collections::{HashMap, HashSet};
 use std::fs;
@@ -145,7 +146,7 @@ fn main() -> Result<()> {
             Commands::CreateMigration { out_dir, name } => {
                 dbschema::validate(&filtered, cli.strict)?;
                 let artifact =
-                    dbschema::generate_with_backend(&cli.backend, &filtered, &env, cli.strict)?;
+                    dbschema::generate_with_backend(&cli.backend, &filtered, cli.strict)?;
                 if let Some(dir) = out_dir {
                     let name = name.unwrap_or_else(|| "triggers".to_string());
                     let ext = dbschema::backends::get_backend(&cli.backend)
@@ -235,7 +236,7 @@ fn run_target(dbschema_config: &DbschemaConfig, target: &TargetConfig, strict: b
     let filtered = apply_filters(&config, &include_set, &exclude_set);
 
     validate(&filtered, strict)?;
-    let artifact = dbschema::generate_with_backend(&target.backend, &filtered, &env, strict)?;
+    let artifact = dbschema::generate_with_backend(&target.backend, &filtered, strict)?;
 
     if let Some(output_path) = &target.output {
         let path = Path::new(output_path);
@@ -451,7 +452,7 @@ include = ["tables"]
         let main_hcl = r#"
 variable "table_name" { default = "users" }
 table "users" {
-    name = var.table_name
+    table_name = var.table_name
 }
 function "my_func" {
     returns = "trigger"


### PR DESCRIPTION
## Summary
- move environment variable handling from `ir` to `frontend`
- drop env vars from backend generation APIs and implementations
- adjust CLI and modules to use `frontend::env::EnvVars`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b6e266063c8331b93194bb93e7c300