### PR TITLE
Use anyhow for config loading

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -147,12 +148,12 @@ impl TargetConfig {
 }
 
 /// Load configuration from dbschema.toml file
-pub fn load_config() -> Result<Option<Config>, Box<dyn std::error::Error>> {
-    load_config_from_path(&Path::new("dbschema.toml"))
+pub fn load_config() -> Result<Option<Config>> {
+    load_config_from_path(Path::new("dbschema.toml"))
 }
 
 /// Load configuration from a specific path
-pub fn load_config_from_path(path: &Path) -> Result<Option<Config>, Box<dyn std::error::Error>> {
+pub fn load_config_from_path(path: &Path) -> Result<Option<Config>> {
     if !path.exists() {
         return Ok(None);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,7 +87,6 @@ fn main() -> Result<()> {
 
     if cli.config {
         let dbschema_config = config::load_config()
-            .map_err(|e| anyhow::Error::msg(e.to_string()))
             .with_context(|| "failed to load dbschema.toml")?
             .ok_or_else(|| anyhow!("dbschema.toml not found"))?;
 
@@ -477,7 +476,6 @@ table_name = "from_file"
         fs::write(&var_file_path, var_file)?;
 
         let dbschema_config = config::load_config_from_path(&dbschema_toml_path)
-            .map_err(|e| anyhow::Error::msg(e.to_string()))
             .with_context(|| "failed to load dbschema.toml")?
             .ok_or_else(|| anyhow!("dbschema.toml not found"))?;
 


### PR DESCRIPTION
## Summary
- Switch `config::load_config` and `load_config_from_path` to return `anyhow::Result<Option<Config>>`
- Simplify callers to rely on `anyhow` errors

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b6ec768e6483318b5e852f15d08d58