### PR TITLE
feat: add output resource for modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Prisma ORM support custom migrations, so you can use this tool to generate an SQ
    - `extension`
    - `policy`
    - `module`
+   - `output`
    - `test`
 
 - Variables via `--var key=value` and `--var-file`.
@@ -307,10 +308,6 @@ table "users" {
 ```
 
 ## Roadmap
-
-### Planned feature
-
-- Module outputs and references (`module.foo.*`).
 
 ### Non-goals (for now)
 

--- a/src/frontend/ast/mod.rs
+++ b/src/frontend/ast/mod.rs
@@ -1,3 +1,5 @@
+use hcl::Value;
+
 #[derive(Debug, Clone, Default)]
 pub struct Config {
     pub functions: Vec<AstFunction>,
@@ -10,6 +12,7 @@ pub struct Config {
     pub materialized: Vec<AstMaterializedView>,
     pub policies: Vec<AstPolicy>,
     pub tests: Vec<AstTest>,
+    pub outputs: Vec<AstOutput>,
 }
 
 #[derive(Debug, Clone)]
@@ -153,4 +156,10 @@ pub struct AstTest {
     pub setup: Vec<String>,
     pub assert_sql: String,
     pub teardown: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AstOutput {
+    pub name: String,
+    pub value: Value,
 }

--- a/src/frontend/env.rs
+++ b/src/frontend/env.rs
@@ -2,9 +2,10 @@ use std::collections::HashMap;
 
 /// Variables available during expression evaluation.
 ///
-/// The evaluation engine exposes three namespaces:
+/// The evaluation engine exposes several namespaces:
 /// - `var.<name>` for values in [`Self::vars`]
 /// - `local.<name>` or `locals.<name>` for values in [`Self::locals`]
+/// - `module.<name>.<output>` for outputs produced by modules
 /// - `each.key`/`each.value` inside `for_each` blocks
 ///
 /// # Example
@@ -16,6 +17,7 @@ use std::collections::HashMap;
 /// let env = EnvVars {
 ///     vars: HashMap::from([( "name".into(), Value::from("world"))]),
 ///     locals: HashMap::from([( "name".into(), Value::from("bob"))]),
+///     modules: HashMap::new(),
 ///     each: None,
 /// };
 /// // `local.name` resolves to "bob" while `var.name` resolves to "world".
@@ -26,6 +28,8 @@ pub struct EnvVars {
     pub vars: HashMap<String, hcl::Value>,
     /// Locally defined values, resolved as `local.*` or `locals.*`.
     pub locals: HashMap<String, hcl::Value>,
+    /// Outputs from loaded modules, referenced as `module.<name>.<output>`.
+    pub modules: HashMap<String, HashMap<String, hcl::Value>>,
     /// Key/value for the current iteration of a `for_each` block, enabling `each.key` and `each.value`.
     pub each: Option<(hcl::Value, hcl::Value)>, // (key, value)
 }

--- a/src/frontend/lower.rs
+++ b/src/frontend/lower.rs
@@ -17,6 +17,7 @@ pub fn lower_config(ast: ast::Config) -> ir::Config {
             .collect(),
         policies: ast.policies.into_iter().map(lower_policy).collect(),
         tests: ast.tests.into_iter().map(lower_test).collect(),
+        outputs: ast.outputs.into_iter().map(lower_output).collect(),
     }
 }
 
@@ -179,5 +180,12 @@ fn lower_test(t: ast::AstTest) -> ir::TestSpec {
         setup: t.setup,
         assert_sql: t.assert_sql,
         teardown: t.teardown,
+    }
+}
+
+fn lower_output(o: ast::AstOutput) -> ir::OutputSpec {
+    ir::OutputSpec {
+        name: o.name,
+        value: o.value,
     }
 }

--- a/src/ir/config.rs
+++ b/src/ir/config.rs
@@ -1,3 +1,4 @@
+use hcl::Value;
 use serde::Serialize;
 
 #[derive(Debug, Clone, Default, Serialize)]
@@ -12,6 +13,7 @@ pub struct Config {
     pub materialized: Vec<MaterializedViewSpec>,
     pub policies: Vec<PolicySpec>,
     pub tests: Vec<TestSpec>,
+    pub outputs: Vec<OutputSpec>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -157,3 +159,8 @@ pub struct TestSpec {
     pub teardown: Vec<String>,
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub struct OutputSpec {
+    pub name: String,
+    pub value: Value,
+}

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -1,7 +1,7 @@
 pub mod config;
 
 pub use config::{
-    BackReferenceSpec, ColumnSpec, Config, EnumSpec, ExtensionSpec, ForeignKeySpec,
-    FunctionSpec, IndexSpec, MaterializedViewSpec, PolicySpec, PrimaryKeySpec, SchemaSpec,
-    TableSpec, TestSpec, TriggerSpec, ViewSpec,
+    BackReferenceSpec, ColumnSpec, Config, EnumSpec, ExtensionSpec, ForeignKeySpec, FunctionSpec,
+    IndexSpec, MaterializedViewSpec, OutputSpec, PolicySpec, PrimaryKeySpec, SchemaSpec, TableSpec,
+    TestSpec, TriggerSpec, ViewSpec,
 };


### PR DESCRIPTION
## Summary
- support `output` blocks and cross-module references via `module.<name>.<output>`
- expose module outputs in expression evaluator and CLI
- document outputs and remove completed roadmap item

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b6f102aa148331b93095e17243170d