### PR TITLE
Implement From conversions for AST to IR types

### DIFF
--- a/src/frontend/core.rs
+++ b/src/frontend/core.rs
@@ -12,7 +12,6 @@ use crate::frontend::ast;
 use crate::frontend::builtins;
 use crate::frontend::env::EnvVars;
 use crate::frontend::for_each::execute_for_each;
-use crate::frontend::lower;
 use crate::ir;
 use crate::Loader;
 
@@ -350,7 +349,7 @@ pub fn load_root_with_loader(
         .unwrap_or_else(|| PathBuf::from("."));
     let mut visited = Vec::new();
     let ast_cfg = load_file(loader, &path, &base, &root_env, &mut visited)?;
-    let mut cfg = lower::lower_config(ast_cfg);
+    let mut cfg: ir::Config = ast_cfg.into();
     populate_back_references(&mut cfg)?;
     Ok(cfg)
 }

--- a/src/frontend/lower.rs
+++ b/src/frontend/lower.rs
@@ -1,18 +1,20 @@
 use crate::frontend::ast;
 use crate::ir;
 
-pub fn lower_config(ast: ast::Config) -> ir::Config {
-    ir::Config {
-        functions: ast.functions.into_iter().map(Into::into).collect(),
-        triggers: ast.triggers.into_iter().map(Into::into).collect(),
-        extensions: ast.extensions.into_iter().map(Into::into).collect(),
-        schemas: ast.schemas.into_iter().map(Into::into).collect(),
-        enums: ast.enums.into_iter().map(Into::into).collect(),
-        tables: ast.tables.into_iter().map(Into::into).collect(),
-        views: ast.views.into_iter().map(Into::into).collect(),
-        materialized: ast.materialized.into_iter().map(Into::into).collect(),
-        policies: ast.policies.into_iter().map(Into::into).collect(),
-        tests: ast.tests.into_iter().map(Into::into).collect(),
+impl From<ast::Config> for ir::Config {
+    fn from(ast: ast::Config) -> Self {
+        Self {
+            functions: ast.functions.into_iter().map(Into::into).collect(),
+            triggers: ast.triggers.into_iter().map(Into::into).collect(),
+            extensions: ast.extensions.into_iter().map(Into::into).collect(),
+            schemas: ast.schemas.into_iter().map(Into::into).collect(),
+            enums: ast.enums.into_iter().map(Into::into).collect(),
+            tables: ast.tables.into_iter().map(Into::into).collect(),
+            views: ast.views.into_iter().map(Into::into).collect(),
+            materialized: ast.materialized.into_iter().map(Into::into).collect(),
+            policies: ast.policies.into_iter().map(Into::into).collect(),
+            tests: ast.tests.into_iter().map(Into::into).collect(),
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Convert AST structs into IR specs using `From` impls
- Replace `lower_*` helpers with `map(Into::into)` for collection lowering

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b6f2cd47b083318c6a9ac6a4966163