### PR TITLE
Stub PGlite in-memory backend

### DIFF
--- a/src/test_runner/mod.rs
+++ b/src/test_runner/mod.rs
@@ -4,6 +4,7 @@ use std::collections::HashSet;
 use crate::ir::Config;
 
 pub mod postgres;
+pub mod pglite;
 
 pub struct TestResult {
     pub name: String,

--- a/src/test_runner/pglite.rs
+++ b/src/test_runner/pglite.rs
@@ -1,0 +1,23 @@
+use anyhow::{anyhow, Result};
+use std::collections::HashSet;
+
+use super::{TestBackend, TestSummary};
+use crate::ir::Config;
+
+/// In-memory Postgres backend powered by the PGlite WASM build.
+///
+/// At the moment this is only a stub that documents the intended
+/// integration. The full WASM runtime and SQL execution logic still
+/// needs to be implemented.
+pub struct PGliteTestBackend;
+
+impl TestBackend for PGliteTestBackend {
+    fn run(
+        &self,
+        _cfg: &Config,
+        _dsn: &str,
+        _only: Option<&HashSet<String>>,
+    ) -> Result<TestSummary> {
+        Err(anyhow!("PGlite backend not implemented"))
+    }
+}


### PR DESCRIPTION
## Summary
- lay groundwork for a future PGlite-based in-memory database backend
- expose `pglite` module in the test runner

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b6faa32ee88331b2f29d956b714ddf