### PR TITLE
Introduce Postgres SQL AST and backend integration

### DIFF
--- a/src/backends/postgres.rs
+++ b/src/backends/postgres.rs
@@ -1,20 +1,6 @@
-use anyhow::Result;
-
 use super::Backend;
-use crate::ir::{
-    Config, EnumSpec, ExtensionSpec, ForeignKeySpec, FunctionSpec, IndexSpec, MaterializedViewSpec,
-    PolicySpec, SchemaSpec, TableSpec, TriggerSpec, ViewSpec,
-};
-
-fn ident(s: &str) -> String {
-    let escaped = s.replace('"', "\"");
-    format!("\"{}\"", escaped)
-}
-
-fn literal(s: &str) -> String {
-    let escaped = s.replace("'", "''");
-    format!("'{}'", escaped)
-}
+use crate::{ir::*, postgres as pg};
+use anyhow::Result;
 
 pub struct PostgresBackend;
 
@@ -29,377 +15,48 @@ impl Backend for PostgresBackend {
         to_sql(cfg)
     }
 }
+
 fn to_sql(cfg: &Config) -> Result<String> {
     let mut out = String::new();
 
-    // Schemas first
     for s in &cfg.schemas {
-        out.push_str(&render_schema(s));
-        out.push_str("\n\n");
+        out.push_str(&format!("{}\n\n", pg::Schema::from(s)));
     }
 
-    // Extensions first
     for e in &cfg.extensions {
-        out.push_str(&render_extension(e));
-        out.push_str("\n\n");
+        out.push_str(&format!("{}\n\n", pg::Extension::from(e)));
     }
 
-    // Enums next (types used by tables)
     for e in &cfg.enums {
-        out.push_str(&render_enum(e));
-        out.push_str("\n\n");
+        out.push_str(&format!("{}\n\n", pg::Enum::from(e)));
     }
 
-    // Tables next
     for t in &cfg.tables {
-        out.push_str(&render_table(t));
-        out.push_str("\n\n");
-        // Indexes after table creation
+        out.push_str(&format!("{}\n\n", pg::Table::from(t)));
         for idx in &t.indexes {
-            out.push_str(&render_index(t, idx));
-            out.push_str("\n\n");
+            out.push_str(&format!("{}\n\n", pg::Index::from_specs(t, idx)));
         }
     }
 
-    // Policies (row-level security) after tables
     for p in &cfg.policies {
-        out.push_str(&render_policy(p));
-        out.push_str("\n\n");
+        out.push_str(&format!("{}\n\n", pg::Policy::from(p)));
     }
 
     for f in &cfg.functions {
-        out.push_str(&render_function(f));
-        out.push_str("\n\n");
+        out.push_str(&format!("{}\n\n", pg::Function::from(f)));
     }
 
-    // Views after functions (they may use functions) and before triggers
     for v in &cfg.views {
-        out.push_str(&render_view(v));
-        out.push_str("\n\n");
+        out.push_str(&format!("{}\n\n", pg::View::from(v)));
     }
 
-    // Materialized views after views
     for mv in &cfg.materialized {
-        out.push_str(&render_materialized(mv));
-        out.push_str("\n\n");
+        out.push_str(&format!("{}\n\n", pg::MaterializedView::from(mv)));
     }
 
     for t in &cfg.triggers {
-        out.push_str(&render_trigger(t));
-        out.push_str("\n\n");
+        out.push_str(&format!("{}\n\n", pg::Trigger::from(t)));
     }
 
     Ok(out)
-}
-
-fn render_extension(e: &ExtensionSpec) -> String {
-    let name = e.alt_name.as_deref().unwrap_or(&e.name);
-    let mut s = String::from("CREATE EXTENSION ");
-    if e.if_not_exists {
-        s.push_str("IF NOT EXISTS ");
-    }
-    s.push_str(&ident(name));
-    let mut with_parts = Vec::new();
-    if let Some(schema) = &e.schema {
-        with_parts.push(format!("SCHEMA {}", ident(schema)));
-    }
-    if let Some(version) = &e.version {
-        // version is a literal string
-        with_parts.push(format!("VERSION {}", literal(version)));
-    }
-    if !with_parts.is_empty() {
-        s.push_str(" WITH ");
-        s.push_str(&with_parts.join(" "));
-    }
-    s.push(';');
-    s
-}
-
-fn render_schema(s: &SchemaSpec) -> String {
-    let name = s.alt_name.as_deref().unwrap_or(&s.name);
-    let mut stmt = String::from("CREATE ");
-    if s.if_not_exists {
-        stmt.push_str("SCHEMA IF NOT EXISTS ");
-    } else {
-        stmt.push_str("SCHEMA ");
-    }
-    stmt.push_str(&ident(name));
-    if let Some(auth) = &s.authorization {
-        stmt.push_str(" AUTHORIZATION ");
-        stmt.push_str(&ident(auth));
-    }
-    stmt.push(';');
-    stmt
-}
-
-fn render_enum(e: &EnumSpec) -> String {
-    let name = e.alt_name.as_deref().unwrap_or(&e.name);
-    let schema = e.schema.as_deref().unwrap_or("public");
-    let values = e
-        .values
-        .iter()
-        .map(|v| literal(v))
-        .collect::<Vec<_>>()
-        .join(", ");
-    format!(
-        "DO $$\nBEGIN\n  IF NOT EXISTS (\n    SELECT 1 FROM pg_type t\n    JOIN pg_namespace n ON n.oid = t.typnamespace\n    WHERE t.typname = {name_lit}\n      AND n.nspname = {schema_lit}\n  ) THEN\n    CREATE TYPE {schema_ident}.{name_ident} AS ENUM ({values});\n  END IF;\nEND$$;",
-        schema_lit = literal(schema),
-        name_lit = literal(name),
-        schema_ident = ident(schema),
-        name_ident = ident(name),
-        values = values,
-    )
-}
-
-fn render_function(f: &FunctionSpec) -> String {
-    let name = f.alt_name.as_deref().unwrap_or(&f.name);
-    let schema = f.schema.as_deref().unwrap_or("public");
-    let definer = if f.security_definer {
-        " SECURITY DEFINER"
-    } else {
-        ""
-    };
-    let or_replace = if f.replace { "OR REPLACE " } else { "" };
-    let lang = f.language.to_lowercase();
-    format!(
-        "CREATE {or_replace}FUNCTION {schema}.{name}() RETURNS {returns} LANGUAGE {lang}{definer} AS $$\\n{body}\\n$$;",
-        schema = ident(schema),
-        name = ident(name),
-        returns = f.returns,
-        lang = lang,
-        definer = definer,
-        body = f.body
-    )
-}
-
-fn render_view(v: &ViewSpec) -> String {
-    let name = v.alt_name.as_deref().unwrap_or(&v.name);
-    let schema = v.schema.as_deref().unwrap_or("public");
-    let or_replace = if v.replace { "OR REPLACE " } else { "" };
-    format!(
-        "CREATE {or_replace}VIEW {schema}.{name} AS\\n{body};",
-        or_replace = or_replace,
-        schema = ident(schema),
-        name = ident(name),
-        body = v.sql
-    )
-}
-
-fn render_materialized(mv: &MaterializedViewSpec) -> String {
-    let name = mv.alt_name.as_deref().unwrap_or(&mv.name);
-    let schema = mv.schema.as_deref().unwrap_or("public");
-    let with = if mv.with_data {
-        "WITH DATA"
-    } else {
-        "WITH NO DATA"
-    };
-    format!(
-        "DO $$\nBEGIN\n  IF NOT EXISTS (\n    SELECT 1 FROM pg_matviews WHERE schemaname = {schema_lit} AND matviewname = {name_lit}\n  ) THEN\n    CREATE MATERIALIZED VIEW {schema_ident}.{name_ident} AS\\n{body}\\n    {with};\n  END IF;\nEND$$;",
-        schema_lit = literal(schema),
-        name_lit = literal(name),
-        schema_ident = ident(schema),
-        name_ident = ident(name),
-        body = mv.sql,
-        with = with,
-    )
-}
-
-fn render_table(t: &TableSpec) -> String {
-    let name = t.table_name.as_deref().unwrap_or(&t.name);
-    let schema = t.schema.as_deref().unwrap_or("public");
-    let mut lines: Vec<String> = Vec::new();
-    for c in &t.columns {
-        let mut l = format!("{} {}", ident(&c.name), c.r#type);
-        if !c.nullable {
-            l.push_str(" NOT NULL");
-        }
-        if let Some(d) = &c.default {
-            l.push_str(&format!(" DEFAULT {}", d));
-        }
-        lines.push(l);
-    }
-    if let Some(pk) = &t.primary_key {
-        let cols = pk
-            .columns
-            .iter()
-            .map(|c| ident(c))
-            .collect::<Vec<_>>()
-            .join(", ");
-        match &pk.name {
-            Some(n) => lines.push(format!("CONSTRAINT {} PRIMARY KEY ({})", ident(n), cols)),
-            None => lines.push(format!("PRIMARY KEY ({})", cols)),
-        }
-    }
-    for fk in &t.foreign_keys {
-        lines.push(render_fk_inline(fk));
-    }
-    let body = lines
-        .into_iter()
-        .map(|l| format!("  {}", l))
-        .collect::<Vec<_>>()
-        .join(",\n");
-    let ine = if t.if_not_exists {
-        " IF NOT EXISTS"
-    } else {
-        ""
-    };
-    format!(
-        "CREATE TABLE{ine} {schema}.{name} (\\n{body}\\n);",
-        ine = ine,
-        schema = ident(schema),
-        name = ident(name),
-        body = body,
-    )
-}
-
-fn render_fk_inline(fk: &ForeignKeySpec) -> String {
-    let cols = fk
-        .columns
-        .iter()
-        .map(|c| ident(c))
-        .collect::<Vec<_>>()
-        .join(", ");
-    let ref_schema = fk.ref_schema.as_deref().unwrap_or("public");
-    let ref_cols = fk
-        .ref_columns
-        .iter()
-        .map(|c| ident(c))
-        .collect::<Vec<_>>()
-        .join(", ");
-    let mut s = String::new();
-    if let Some(n) = &fk.name {
-        s.push_str(&format!("CONSTRAINT {} ", ident(n)));
-    }
-    s.push_str(&format!(
-        "FOREIGN KEY ({cols}) REFERENCES {rschema}.{rtable} ({rcols})",
-        cols = cols,
-        rschema = ident(ref_schema),
-        rtable = ident(&fk.ref_table),
-        rcols = ref_cols,
-    ));
-    if let Some(od) = &fk.on_delete {
-        s.push_str(&format!(" ON DELETE {}", od));
-    }
-    if let Some(ou) = &fk.on_update {
-        s.push_str(&format!(" ON UPDATE {}", ou));
-    }
-    s
-}
-
-fn render_index(t: &TableSpec, idx: &IndexSpec) -> String {
-    let table_name = t.table_name.as_deref().unwrap_or(&t.name);
-    let schema = t.schema.as_deref().unwrap_or("public");
-    let cols = idx
-        .columns
-        .iter()
-        .map(|c| ident(c))
-        .collect::<Vec<_>>()
-        .join(", ");
-    let unique = if idx.unique { "UNIQUE " } else { "" };
-    let name = match &idx.name {
-        Some(n) => ident(n),
-        None => {
-            // derive name: <table>_<col1>_<col2>_idx/uniq
-            let mut n = format!(
-                "{}_{}_{}",
-                table_name,
-                idx.columns.join("_"),
-                if idx.unique { "uniq" } else { "idx" }
-            );
-            n = n.replace('.', "_");
-            ident(&n)
-        }
-    };
-    format!(
-        "CREATE {unique}INDEX IF NOT EXISTS {name} ON {schema}.{table} ({cols});",
-        unique = unique,
-        name = name,
-        schema = ident(schema),
-        table = ident(table_name),
-        cols = cols,
-    )
-}
-
-fn render_trigger(t: &TriggerSpec) -> String {
-    let name = t.name.clone();
-    let schema = t.schema.as_deref().unwrap_or("public");
-    let fn_schema = t.function_schema.as_deref().unwrap_or(schema);
-    let timing = t.timing.to_uppercase();
-    let events = t
-        .events
-        .iter()
-        .map(|e| e.to_uppercase())
-        .collect::<Vec<_>>()
-        .join(" OR ");
-    let for_each = t.level.to_uppercase();
-    let when = t
-        .when
-        .as_ref()
-        .map(|w| format!("\n    WHEN ({})", w))
-        .unwrap_or_default();
-
-    format!(
-        "DO $$\nBEGIN\n  IF NOT EXISTS (\n    SELECT 1 FROM pg_trigger tg\n    JOIN pg_class c ON c.oid = tg.tgrelid\n    JOIN pg_namespace n ON n.oid = c.relnamespace\n    WHERE tg.tgname = {tgname}\n      AND n.nspname = {schema_lit}\n      AND c.relname = {table_lit}\n  ) THEN\n    CREATE TRIGGER {tg}\n    {timing} {events} ON {schema_ident}.{table_ident}\n    FOR EACH {for_each}{when}\n    EXECUTE FUNCTION {fn_schema_ident}.{fn_name}();\n  END IF;\nEND$$;",
-        tgname = literal(&name),
-        schema_lit = literal(schema),
-        table_lit = literal(&t.table),
-        tg = ident(&name),
-        timing = timing,
-        events = events,
-        for_each = for_each,
-        when = when,
-        schema_ident = ident(schema),
-        table_ident = ident(&t.table),
-        fn_schema_ident = ident(fn_schema),
-        fn_name = ident(&t.function)
-    )
-}
-
-fn render_policy(p: &PolicySpec) -> String {
-    let name = p.alt_name.as_deref().unwrap_or(&p.name);
-    let schema = p.schema.as_deref().unwrap_or("public");
-    let cmd = p.command.to_uppercase();
-    let as_clause = match p.r#as.as_ref().map(|s| s.to_uppercase()) {
-        Some(ref k) if k == "PERMISSIVE" || k == "RESTRICTIVE" => format!(" AS {}", k),
-        _ => String::new(),
-    };
-    let for_clause = if cmd == "ALL" {
-        String::new()
-    } else {
-        format!(" FOR {}", cmd)
-    };
-    let to_clause = if p.roles.is_empty() {
-        String::new()
-    } else {
-        let roles = p
-            .roles
-            .iter()
-            .map(|r| ident(r))
-            .collect::<Vec<_>>()
-            .join(", ");
-        format!(" TO {}", roles)
-    };
-    let using_clause = match &p.using {
-        Some(u) => format!("\n    USING ({})", u),
-        None => String::new(),
-    };
-    let check_clause = match &p.check {
-        Some(c) => format!("\n    WITH CHECK ({})", c),
-        None => String::new(),
-    };
-
-    format!(
-        "DO $$\nBEGIN\n  IF NOT EXISTS (\n    SELECT 1 FROM pg_policies\n    WHERE policyname = {pname}\n      AND schemaname = {schema_lit}\n      AND tablename = {table_lit}\n  ) THEN\n    CREATE POLICY {pname_ident} ON {schema_ident}.{table_ident}{as_clause}{for_clause}{to_clause}{using}{check};\n  END IF;\nEND$$;",
-        pname = literal(name),
-        schema_lit = literal(schema),
-        table_lit = literal(&p.table),
-        pname_ident = ident(name),
-        schema_ident = ident(schema),
-        table_ident = ident(&p.table),
-        as_clause = as_clause,
-        for_clause = for_clause,
-        to_clause = to_clause,
-        using = using_clause,
-        check = check_clause,
-    )
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod config;
 pub mod frontend;
 pub mod ir;
 pub mod passes;
+pub mod postgres;
 pub mod prisma;
 pub mod test_runner;
 

--- a/src/postgres/mod.rs
+++ b/src/postgres/mod.rs
@@ -1,0 +1,614 @@
+use std::fmt;
+
+pub fn ident(s: &str) -> String {
+    let escaped = s.replace('"', "\"");
+    format!("\"{}\"", escaped)
+}
+
+pub fn literal(s: &str) -> String {
+    let escaped = s.replace("'", "''");
+    format!("'{}'", escaped)
+}
+
+#[derive(Debug, Clone)]
+pub struct Extension {
+    pub name: String,
+    pub if_not_exists: bool,
+    pub schema: Option<String>,
+    pub version: Option<String>,
+}
+
+impl From<&crate::ir::ExtensionSpec> for Extension {
+    fn from(s: &crate::ir::ExtensionSpec) -> Self {
+        Self {
+            name: s.alt_name.clone().unwrap_or_else(|| s.name.clone()),
+            if_not_exists: s.if_not_exists,
+            schema: s.schema.clone(),
+            version: s.version.clone(),
+        }
+    }
+}
+
+impl fmt::Display for Extension {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "CREATE EXTENSION ")?;
+        if self.if_not_exists {
+            write!(f, "IF NOT EXISTS ")?;
+        }
+        write!(f, "{}", ident(&self.name))?;
+        let mut with_parts = Vec::new();
+        if let Some(schema) = &self.schema {
+            with_parts.push(format!("SCHEMA {}", ident(schema)));
+        }
+        if let Some(version) = &self.version {
+            with_parts.push(format!("VERSION {}", literal(version)));
+        }
+        if !with_parts.is_empty() {
+            write!(f, " WITH {}", with_parts.join(" "))?;
+        }
+        write!(f, ";")
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Schema {
+    pub name: String,
+    pub if_not_exists: bool,
+    pub authorization: Option<String>,
+}
+
+impl From<&crate::ir::SchemaSpec> for Schema {
+    fn from(s: &crate::ir::SchemaSpec) -> Self {
+        Self {
+            name: s.alt_name.clone().unwrap_or_else(|| s.name.clone()),
+            if_not_exists: s.if_not_exists,
+            authorization: s.authorization.clone(),
+        }
+    }
+}
+
+impl fmt::Display for Schema {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.if_not_exists {
+            write!(f, "CREATE SCHEMA IF NOT EXISTS {}", ident(&self.name))?;
+        } else {
+            write!(f, "CREATE SCHEMA {}", ident(&self.name))?;
+        }
+        if let Some(auth) = &self.authorization {
+            write!(f, " AUTHORIZATION {}", ident(auth))?;
+        }
+        write!(f, ";")
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Enum {
+    pub schema: String,
+    pub name: String,
+    pub values: Vec<String>,
+}
+
+impl From<&crate::ir::EnumSpec> for Enum {
+    fn from(e: &crate::ir::EnumSpec) -> Self {
+        Self {
+            schema: e.schema.clone().unwrap_or_else(|| "public".to_string()),
+            name: e.alt_name.clone().unwrap_or_else(|| e.name.clone()),
+            values: e.values.clone(),
+        }
+    }
+}
+
+impl fmt::Display for Enum {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let values = self
+            .values
+            .iter()
+            .map(|v| literal(v))
+            .collect::<Vec<_>>()
+            .join(", ");
+        write!(
+            f,
+            "DO $$\nBEGIN\n  IF NOT EXISTS (\n    SELECT 1 FROM pg_type t\n    JOIN pg_namespace n ON n.oid = t.typnamespace\n    WHERE t.typname = {name_lit}\n      AND n.nspname = {schema_lit}\n  ) THEN\n    CREATE TYPE {schema_ident}.{name_ident} AS ENUM ({values});\n  END IF;\nEND$$;",
+            name_lit = literal(&self.name),
+            schema_lit = literal(&self.schema),
+            schema_ident = ident(&self.schema),
+            name_ident = ident(&self.name),
+            values = values,
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Function {
+    pub schema: String,
+    pub name: String,
+    pub language: String,
+    pub returns: String,
+    pub replace: bool,
+    pub security_definer: bool,
+    pub body: String,
+}
+
+impl From<&crate::ir::FunctionSpec> for Function {
+    fn from(f: &crate::ir::FunctionSpec) -> Self {
+        Self {
+            schema: f.schema.clone().unwrap_or_else(|| "public".to_string()),
+            name: f.alt_name.clone().unwrap_or_else(|| f.name.clone()),
+            language: f.language.clone(),
+            returns: f.returns.clone(),
+            replace: f.replace,
+            security_definer: f.security_definer,
+            body: f.body.clone(),
+        }
+    }
+}
+
+impl fmt::Display for Function {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let definer = if self.security_definer {
+            " SECURITY DEFINER"
+        } else {
+            ""
+        };
+        let or_replace = if self.replace { "OR REPLACE " } else { "" };
+        write!(
+            f,
+            "CREATE {or_replace}FUNCTION {schema}.{name}() RETURNS {returns} LANGUAGE {lang}{definer} AS $$\n{body}\n$$;",
+            or_replace = or_replace,
+            schema = ident(&self.schema),
+            name = ident(&self.name),
+            returns = self.returns,
+            lang = self.language.to_lowercase(),
+            definer = definer,
+            body = self.body,
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct View {
+    pub schema: String,
+    pub name: String,
+    pub sql: String,
+    pub replace: bool,
+}
+
+impl From<&crate::ir::ViewSpec> for View {
+    fn from(v: &crate::ir::ViewSpec) -> Self {
+        Self {
+            schema: v.schema.clone().unwrap_or_else(|| "public".to_string()),
+            name: v.alt_name.clone().unwrap_or_else(|| v.name.clone()),
+            sql: v.sql.clone(),
+            replace: v.replace,
+        }
+    }
+}
+
+impl fmt::Display for View {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let or_replace = if self.replace { "OR REPLACE " } else { "" };
+        write!(
+            f,
+            "CREATE {or_replace}VIEW {schema}.{name} AS\n{body};",
+            or_replace = or_replace,
+            schema = ident(&self.schema),
+            name = ident(&self.name),
+            body = self.sql,
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct MaterializedView {
+    pub schema: String,
+    pub name: String,
+    pub sql: String,
+    pub with_data: bool,
+}
+
+impl From<&crate::ir::MaterializedViewSpec> for MaterializedView {
+    fn from(m: &crate::ir::MaterializedViewSpec) -> Self {
+        Self {
+            schema: m.schema.clone().unwrap_or_else(|| "public".to_string()),
+            name: m.alt_name.clone().unwrap_or_else(|| m.name.clone()),
+            sql: m.sql.clone(),
+            with_data: m.with_data,
+        }
+    }
+}
+
+impl fmt::Display for MaterializedView {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let with = if self.with_data {
+            "WITH DATA"
+        } else {
+            "WITH NO DATA"
+        };
+        write!(
+            f,
+            "DO $$\nBEGIN\n  IF NOT EXISTS (\n    SELECT 1 FROM pg_matviews WHERE schemaname = {schema_lit} AND matviewname = {name_lit}\n  ) THEN\n    CREATE MATERIALIZED VIEW {schema_ident}.{name_ident} AS\n{body}\n    {with};\n  END IF;\nEND$$;",
+            schema_lit = literal(&self.schema),
+            name_lit = literal(&self.name),
+            schema_ident = ident(&self.schema),
+            name_ident = ident(&self.name),
+            body = self.sql,
+            with = with,
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Column {
+    pub name: String,
+    pub r#type: String,
+    pub nullable: bool,
+    pub default: Option<String>,
+}
+
+impl From<&crate::ir::ColumnSpec> for Column {
+    fn from(c: &crate::ir::ColumnSpec) -> Self {
+        Self {
+            name: c.name.clone(),
+            r#type: c.r#type.clone(),
+            nullable: c.nullable,
+            default: c.default.clone(),
+        }
+    }
+}
+
+impl fmt::Display for Column {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} {}", ident(&self.name), self.r#type)?;
+        if !self.nullable {
+            write!(f, " NOT NULL")?;
+        }
+        if let Some(d) = &self.default {
+            write!(f, " DEFAULT {}", d)?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PrimaryKey {
+    pub name: Option<String>,
+    pub columns: Vec<String>,
+}
+
+impl From<&crate::ir::PrimaryKeySpec> for PrimaryKey {
+    fn from(pk: &crate::ir::PrimaryKeySpec) -> Self {
+        Self {
+            name: pk.name.clone(),
+            columns: pk.columns.clone(),
+        }
+    }
+}
+
+impl fmt::Display for PrimaryKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let cols = self
+            .columns
+            .iter()
+            .map(|c| ident(c))
+            .collect::<Vec<_>>()
+            .join(", ");
+        match &self.name {
+            Some(n) => write!(f, "CONSTRAINT {} PRIMARY KEY ({})", ident(n), cols),
+            None => write!(f, "PRIMARY KEY ({})", cols),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ForeignKey {
+    pub name: Option<String>,
+    pub columns: Vec<String>,
+    pub ref_schema: String,
+    pub ref_table: String,
+    pub ref_columns: Vec<String>,
+    pub on_delete: Option<String>,
+    pub on_update: Option<String>,
+}
+
+impl From<&crate::ir::ForeignKeySpec> for ForeignKey {
+    fn from(fk: &crate::ir::ForeignKeySpec) -> Self {
+        Self {
+            name: fk.name.clone(),
+            columns: fk.columns.clone(),
+            ref_schema: fk
+                .ref_schema
+                .clone()
+                .unwrap_or_else(|| "public".to_string()),
+            ref_table: fk.ref_table.clone(),
+            ref_columns: fk.ref_columns.clone(),
+            on_delete: fk.on_delete.clone(),
+            on_update: fk.on_update.clone(),
+        }
+    }
+}
+
+impl fmt::Display for ForeignKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let cols = self
+            .columns
+            .iter()
+            .map(|c| ident(c))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let ref_cols = self
+            .ref_columns
+            .iter()
+            .map(|c| ident(c))
+            .collect::<Vec<_>>()
+            .join(", ");
+        if let Some(n) = &self.name {
+            write!(f, "CONSTRAINT {} ", ident(n))?;
+        }
+        write!(
+            f,
+            "FOREIGN KEY ({cols}) REFERENCES {rschema}.{rtable} ({rcols})",
+            cols = cols,
+            rschema = ident(&self.ref_schema),
+            rtable = ident(&self.ref_table),
+            rcols = ref_cols,
+        )?;
+        if let Some(od) = &self.on_delete {
+            write!(f, " ON DELETE {}", od)?;
+        }
+        if let Some(ou) = &self.on_update {
+            write!(f, " ON UPDATE {}", ou)?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Table {
+    pub schema: String,
+    pub name: String,
+    pub if_not_exists: bool,
+    pub columns: Vec<Column>,
+    pub primary_key: Option<PrimaryKey>,
+    pub foreign_keys: Vec<ForeignKey>,
+}
+
+impl From<&crate::ir::TableSpec> for Table {
+    fn from(t: &crate::ir::TableSpec) -> Self {
+        Self {
+            schema: t.schema.clone().unwrap_or_else(|| "public".to_string()),
+            name: t.table_name.clone().unwrap_or_else(|| t.name.clone()),
+            if_not_exists: t.if_not_exists,
+            columns: t.columns.iter().map(Column::from).collect(),
+            primary_key: t.primary_key.as_ref().map(PrimaryKey::from),
+            foreign_keys: t.foreign_keys.iter().map(ForeignKey::from).collect(),
+        }
+    }
+}
+
+impl fmt::Display for Table {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut lines: Vec<String> = self.columns.iter().map(|c| format!("{}", c)).collect();
+        if let Some(pk) = &self.primary_key {
+            lines.push(format!("{}", pk));
+        }
+        for fk in &self.foreign_keys {
+            lines.push(format!("{}", fk));
+        }
+        let body = lines
+            .into_iter()
+            .map(|l| format!("  {}", l))
+            .collect::<Vec<_>>()
+            .join(",\n");
+        let ine = if self.if_not_exists {
+            " IF NOT EXISTS"
+        } else {
+            ""
+        };
+        write!(
+            f,
+            "CREATE TABLE{ine} {schema}.{name} (\n{body}\n);",
+            ine = ine,
+            schema = ident(&self.schema),
+            name = ident(&self.name),
+            body = body,
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Index {
+    pub table_schema: String,
+    pub table_name: String,
+    pub name: Option<String>,
+    pub columns: Vec<String>,
+    pub unique: bool,
+}
+
+impl Index {
+    pub fn from_specs(table: &crate::ir::TableSpec, idx: &crate::ir::IndexSpec) -> Self {
+        Self {
+            table_schema: table.schema.clone().unwrap_or_else(|| "public".to_string()),
+            table_name: table
+                .table_name
+                .clone()
+                .unwrap_or_else(|| table.name.clone()),
+            name: idx.name.clone(),
+            columns: idx.columns.clone(),
+            unique: idx.unique,
+        }
+    }
+}
+
+impl fmt::Display for Index {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let cols = self
+            .columns
+            .iter()
+            .map(|c| ident(c))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let unique = if self.unique { "UNIQUE " } else { "" };
+        let name = match &self.name {
+            Some(n) => ident(n),
+            None => {
+                let mut n = format!(
+                    "{}_{}_{}",
+                    self.table_name,
+                    self.columns.join("_"),
+                    if self.unique { "uniq" } else { "idx" }
+                );
+                n = n.replace('.', "_");
+                ident(&n)
+            }
+        };
+        write!(
+            f,
+            "CREATE {unique}INDEX IF NOT EXISTS {name} ON {schema}.{table} ({cols});",
+            unique = unique,
+            name = name,
+            schema = ident(&self.table_schema),
+            table = ident(&self.table_name),
+            cols = cols,
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Trigger {
+    pub schema: String,
+    pub table: String,
+    pub name: String,
+    pub timing: String,
+    pub events: Vec<String>,
+    pub level: String,
+    pub function: String,
+    pub function_schema: String,
+    pub when: Option<String>,
+}
+
+impl From<&crate::ir::TriggerSpec> for Trigger {
+    fn from(t: &crate::ir::TriggerSpec) -> Self {
+        Self {
+            schema: t.schema.clone().unwrap_or_else(|| "public".to_string()),
+            table: t.table.clone(),
+            name: t.alt_name.clone().unwrap_or_else(|| t.name.clone()),
+            timing: t.timing.clone(),
+            events: t.events.clone(),
+            level: t.level.clone(),
+            function: t.function.clone(),
+            function_schema: t
+                .function_schema
+                .clone()
+                .unwrap_or_else(|| t.schema.clone().unwrap_or_else(|| "public".to_string())),
+            when: t.when.clone(),
+        }
+    }
+}
+
+impl fmt::Display for Trigger {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let events = self
+            .events
+            .iter()
+            .map(|e| e.to_uppercase())
+            .collect::<Vec<_>>()
+            .join(" OR ");
+        let when = self
+            .when
+            .as_ref()
+            .map(|w| format!("\n    WHEN ({})", w))
+            .unwrap_or_default();
+        write!(
+            f,
+            "DO $$\nBEGIN\n  IF NOT EXISTS (\n    SELECT 1 FROM pg_trigger tg\n    JOIN pg_class c ON c.oid = tg.tgrelid\n    JOIN pg_namespace n ON n.oid = c.relnamespace\n    WHERE tg.tgname = {tgname}\n      AND n.nspname = {schema_lit}\n      AND c.relname = {table_lit}\n  ) THEN\n    CREATE TRIGGER {tg}\n    {timing} {events} ON {schema_ident}.{table_ident}\n    FOR EACH {for_each}{when}\n    EXECUTE FUNCTION {fn_schema_ident}.{fn_name}();\n  END IF;\nEND$$;",
+            tgname = literal(&self.name),
+            schema_lit = literal(&self.schema),
+            table_lit = literal(&self.table),
+            tg = ident(&self.name),
+            timing = self.timing.to_uppercase(),
+            events = events,
+            for_each = self.level.to_uppercase(),
+            when = when,
+            schema_ident = ident(&self.schema),
+            table_ident = ident(&self.table),
+            fn_schema_ident = ident(&self.function_schema),
+            fn_name = ident(&self.function),
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Policy {
+    pub schema: String,
+    pub table: String,
+    pub name: String,
+    pub command: String,
+    pub r#as: Option<String>,
+    pub roles: Vec<String>,
+    pub using: Option<String>,
+    pub check: Option<String>,
+}
+
+impl From<&crate::ir::PolicySpec> for Policy {
+    fn from(p: &crate::ir::PolicySpec) -> Self {
+        Self {
+            schema: p.schema.clone().unwrap_or_else(|| "public".to_string()),
+            table: p.table.clone(),
+            name: p.alt_name.clone().unwrap_or_else(|| p.name.clone()),
+            command: p.command.clone(),
+            r#as: p.r#as.clone(),
+            roles: p.roles.clone(),
+            using: p.using.clone(),
+            check: p.check.clone(),
+        }
+    }
+}
+
+impl fmt::Display for Policy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let cmd = self.command.to_uppercase();
+        let as_clause = match self.r#as.as_ref().map(|s| s.to_uppercase()) {
+            Some(ref k) if k == "PERMISSIVE" || k == "RESTRICTIVE" => format!(" AS {}", k),
+            _ => String::new(),
+        };
+        let for_clause = if cmd == "ALL" {
+            String::new()
+        } else {
+            format!(" FOR {}", cmd)
+        };
+        let to_clause = if self.roles.is_empty() {
+            String::new()
+        } else {
+            let roles = self
+                .roles
+                .iter()
+                .map(|r| ident(r))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!(" TO {}", roles)
+        };
+        let using_clause = match &self.using {
+            Some(u) => format!("\n    USING ({})", u),
+            None => String::new(),
+        };
+        let check_clause = match &self.check {
+            Some(c) => format!("\n    WITH CHECK ({})", c),
+            None => String::new(),
+        };
+        write!(
+            f,
+            "DO $$\nBEGIN\n  IF NOT EXISTS (\n    SELECT 1 FROM pg_policies\n    WHERE policyname = {pname}\n      AND schemaname = {schema_lit}\n      AND tablename = {table_lit}\n  ) THEN\n    CREATE POLICY {pname_ident} ON {schema_ident}.{table_ident}{as_clause}{for_clause}{to_clause}{using}{check};\n  END IF;\nEND$$;",
+            pname = literal(&self.name),
+            schema_lit = literal(&self.schema),
+            table_lit = literal(&self.table),
+            pname_ident = ident(&self.name),
+            schema_ident = ident(&self.schema),
+            table_ident = ident(&self.table),
+            as_clause = as_clause,
+            for_clause = for_clause,
+            to_clause = to_clause,
+            using = using_clause,
+            check = check_clause,
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- add `src/postgres` module providing AST types and `Display` impls for Postgres SQL
- refactor Postgres backend to build AST nodes instead of string interpolation
- expose new module in lib

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b6fb70cd2c83319654f05ebdd787bc