### PR TITLE
Gate pglite support behind feature flag and add REPL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,14 +22,24 @@ postgres = "0.19"
 log = "0.4"
 env_logger = "0.11"
 url = "2"
-wasmtime = "36"
-wasmtime-wasi = "36"
-postgres-protocol = "0.6"
-bytes = "1"
-fallible-iterator = "0.2"
+wasmtime = { version = "36", optional = true }
+wasmtime-wasi = { version = "36", optional = true }
+postgres-protocol = { version = "0.6", optional = true }
+bytes = { version = "1", optional = true }
+fallible-iterator = { version = "0.2", optional = true }
 
 [dev-dependencies]
 tempfile = "3"
+
+[features]
+default = []
+pglite = [
+    "wasmtime",
+    "wasmtime-wasi",
+    "postgres-protocol",
+    "bytes",
+    "fallible-iterator",
+]
 
 [profile.release]
 opt-level = 3

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,12 @@ pub struct Settings {
     /// Environment variables to set
     #[serde(default)]
     pub env: HashMap<String, String>,
+    /// Default backend for `dbschema test`
+    #[serde(default)]
+    pub test_backend: Option<String>,
+    /// Default DSN for `dbschema test`
+    #[serde(default)]
+    pub test_dsn: Option<String>,
 }
 
 /// Configuration for a single target output

--- a/src/test_runner/mod.rs
+++ b/src/test_runner/mod.rs
@@ -4,6 +4,7 @@ use std::collections::HashSet;
 use crate::ir::Config;
 
 pub mod postgres;
+#[cfg(feature = "pglite")]
 pub mod pglite;
 
 pub struct TestResult {

--- a/tests/pglite_backend.rs
+++ b/tests/pglite_backend.rs
@@ -1,0 +1,55 @@
+#[cfg(feature = "pglite")]
+use dbschema::test_runner::{pglite::PGliteTestBackend, TestBackend};
+#[cfg(feature = "pglite")]
+use dbschema::{load_config, Loader};
+#[cfg(feature = "pglite")]
+use dbschema::frontend::env::EnvVars;
+#[cfg(feature = "pglite")]
+use anyhow::Result;
+#[cfg(feature = "pglite")]
+use std::collections::HashMap;
+#[cfg(feature = "pglite")]
+use std::path::Path;
+
+#[cfg(feature = "pglite")]
+struct FsLoader;
+#[cfg(feature = "pglite")]
+impl Loader for FsLoader {
+    fn load(&self, path: &Path) -> Result<String> {
+        Ok(std::fs::read_to_string(path)?)
+    }
+}
+
+#[cfg(feature = "pglite")]
+#[test]
+#[ignore]
+fn pglite_backend_runs_test() -> Result<()> {
+    use std::fs::File;
+    use std::io::Write;
+    use tempfile::tempdir;
+
+    let dir = tempdir()?;
+    let hcl_path = dir.path().join("main.hcl");
+    let mut file = File::create(&hcl_path)?;
+    writeln!(
+        file,
+        r#"test "simple" {{
+  setup = ["CREATE TABLE foo(id int); INSERT INTO foo VALUES (1)"]
+  assert = "SELECT count(*) = 1 FROM foo"
+}}"#
+    )?;
+
+    let loader = FsLoader;
+    let cfg = load_config(&hcl_path, &loader, EnvVars {
+        vars: HashMap::new(),
+        locals: HashMap::new(),
+        modules: HashMap::new(),
+        each: None,
+    })?;
+
+    let backend = PGliteTestBackend;
+    let summary = backend.run(&cfg, "pglite", None)?;
+    assert_eq!(summary.passed, 1);
+    assert_eq!(summary.failed, 0);
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- gate pglite backend behind optional `pglite` feature and expose simple REPL
- allow selecting pglite backend via CLI or `dbschema.toml`
- document pglite usage and assets download; add ignored integration test stub

## Testing
- `cargo test`
- `cargo test --features pglite`

------
https://chatgpt.com/codex/tasks/task_e_68b70c1eda108331a600dbd38b83e3a6