### PR TITLE
refactor pglite runtime into separate crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,8 @@
+[workspace]
+members = [
+    "crates/pglite"
+]
+
 [package]
 name = "dbschema"
 version = "0.1.0"
@@ -22,24 +27,17 @@ postgres = "0.19"
 log = "0.4"
 env_logger = "0.11"
 url = "2"
-wasmtime = { version = "36", optional = true }
-wasmtime-wasi = { version = "36", optional = true }
 postgres-protocol = { version = "0.6", optional = true }
 bytes = { version = "1", optional = true }
 fallible-iterator = { version = "0.2", optional = true }
+pglite = { path = "crates/pglite", optional = true }
 
 [dev-dependencies]
 tempfile = "3"
 
 [features]
 default = []
-pglite = [
-    "wasmtime",
-    "wasmtime-wasi",
-    "postgres-protocol",
-    "bytes",
-    "fallible-iterator",
-]
+pglite = ["dep:pglite", "postgres-protocol", "bytes", "fallible-iterator"]
 
 [profile.release]
 opt-level = 3

--- a/crates/pglite/Cargo.toml
+++ b/crates/pglite/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "pglite"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = "1"
+bytes = "1"
+fallible-iterator = "0.2"
+postgres-protocol = "0.6"
+wasmtime = "36"
+wasmtime-wasi = { version = "36", features=["preview1"] }

--- a/crates/pglite/README.md
+++ b/crates/pglite/README.md
@@ -1,0 +1,35 @@
+# pglite
+
+A Rust wrapper around the PGlite WASM build. This crate exposes a minimal
+runtime for the [`@electric-sql/pglite` npm package](https://www.npmjs.com/package/@electric-sql/pglite),
+allowing tests and applications to run an in-memory PostgreSQL instance via
+WebAssembly.
+
+## Setup
+
+Download the required WebAssembly artifacts with:
+
+```sh
+just --justfile crates/pglite/justfile pglite-assets
+# or from the workspace root
+just pglite-assets
+```
+
+This fetches the `pglite.wasm` and `pglite.data` files into `vendor/pglite`.
+
+## Usage
+
+```rust
+use pglite::PGliteRuntime;
+
+fn main() -> anyhow::Result<()> {
+    let mut rt = PGliteRuntime::new()?;
+    rt.startup()?;
+    let msgs = rt.simple_query("SELECT 1")?;
+    rt.shutdown()?;
+    Ok(())
+}
+```
+
+The runtime exposes simple helpers for startup, query execution and shutdown.
+

--- a/crates/pglite/justfile
+++ b/crates/pglite/justfile
@@ -1,0 +1,9 @@
+set shell := ["bash", "-cu"]
+root := `git rev-parse --show-toplevel`
+
+# Download the PGlite WASM artifacts
+pglite-assets:
+  set -euo pipefail
+  mkdir -p {{root}}/vendor/pglite
+  curl -L -o {{root}}/vendor/pglite/pglite.wasm https://cdn.jsdelivr.net/npm/@electric-sql/pglite/dist/pglite.wasm
+  curl -L -o {{root}}/vendor/pglite/pglite.data https://cdn.jsdelivr.net/npm/@electric-sql/pglite/dist/pglite.data

--- a/crates/pglite/src/lib.rs
+++ b/crates/pglite/src/lib.rs
@@ -1,0 +1,174 @@
+use anyhow::{anyhow, Result};
+use bytes::BytesMut;
+use fallible_iterator::FallibleIterator;
+use postgres_protocol::message::{backend, frontend};
+use wasmtime::{Engine, Instance, Linker, Memory, Module, Store, TypedFunc};
+use wasmtime_wasi::{
+    preview1::{add_to_linker_sync, WasiP1Ctx},
+    DirPerms, FilePerms, WasiCtxBuilder,
+};
+
+/// In-memory Postgres backend powered by the PGlite WASM build.
+///
+/// This backend bootstraps a WASI environment, instantiates the
+/// pre-built `pglite.wasm` module and exposes a minimal wrapper
+/// around the exported functions required to initialise, run and
+/// shutdown the in-memory database. Query execution through the
+/// Postgres wire protocol is handled via an in-memory bridge.
+pub struct PGliteRuntime {
+    store: Store<WasiP1Ctx>,
+    _instance: Instance,
+    memory: Memory,
+    interactive_write: TypedFunc<i32, ()>,
+    interactive_read: TypedFunc<(), i32>,
+    get_channel: TypedFunc<(), i32>,
+    use_wire: TypedFunc<i32, ()>,
+    backend: TypedFunc<(), ()>,
+    shutdown_fn: TypedFunc<(), ()>,
+}
+
+impl PGliteRuntime {
+    /// Load the PGlite module and initialise the database files.
+    pub fn new() -> Result<Self> {
+        // Locate the bundled wasm and data files
+        let wasm_path = "vendor/pglite/pglite.wasm";
+
+        let engine = Engine::default();
+        let module = Module::from_file(&engine, wasm_path)?;
+        let mut linker = Linker::new(&engine);
+        // Minimal host env required by the PGlite module
+        linker.func_wrap("env", "invoke_iii", |_a: i32, _b: i32, _c: i32| -> i32 {
+            0
+        })?;
+        linker.func_wrap(
+            "env",
+            "invoke_viiii",
+            |_a: i32, _b: i32, _c: i32, _d: i32, _e: i32| {},
+        )?;
+        linker.func_wrap("env", "invoke_vi", |_a: i32, _b: i32| {})?;
+        linker.func_wrap("env", "invoke_v", |_a: i32| {})?;
+        linker.func_wrap("env", "invoke_j", |_a: i32| -> i64 { 0 })?;
+        add_to_linker_sync(&mut linker, |ctx: &mut WasiP1Ctx| ctx)?;
+
+        // Preopen the directory containing pglite.data as /tmp/pglite
+        let mut builder = WasiCtxBuilder::new();
+        builder.inherit_stdio().preopened_dir(
+            "vendor/pglite",
+            "/tmp/pglite",
+            DirPerms::all(),
+            FilePerms::all(),
+        )?;
+        let wasi = builder.build_p1();
+        let mut store = Store::new(&engine, wasi);
+        let instance = linker.instantiate(&mut store, &module)?;
+
+        // Call _pgl_initdb to ensure the database files are set up
+        let init = instance.get_typed_func::<(), i32>(&mut store, "_pgl_initdb")?;
+        let rc = init.call(&mut store, ())?;
+        if rc != 0 {
+            return Err(anyhow!("pglite initdb failed with code {rc}"));
+        }
+
+        let memory = instance
+            .get_memory(&mut store, "memory")
+            .ok_or_else(|| anyhow!("missing memory export"))?;
+        let interactive_write =
+            instance.get_typed_func::<i32, ()>(&mut store, "_interactive_write")?;
+        let interactive_read =
+            instance.get_typed_func::<(), i32>(&mut store, "_interactive_read")?;
+        let get_channel = instance.get_typed_func::<(), i32>(&mut store, "_get_channel")?;
+        let use_wire = instance.get_typed_func::<i32, ()>(&mut store, "_use_wire")?;
+        let backend = instance.get_typed_func::<(), ()>(&mut store, "_pgl_backend")?;
+        let shutdown_fn = instance.get_typed_func::<(), ()>(&mut store, "_pgl_shutdown")?;
+
+        Ok(Self {
+            store,
+            _instance: instance,
+            memory,
+            interactive_write,
+            interactive_read,
+            get_channel,
+            use_wire,
+            backend,
+            shutdown_fn,
+        })
+    }
+    /// Execute a single protocol message and return the backend response bytes.
+    fn exec_protocol(&mut self, message: &[u8]) -> Result<Vec<u8>> {
+        self.use_wire.call(&mut self.store, 1)?;
+        self.interactive_write
+            .call(&mut self.store, message.len() as i32)?;
+        let mem = self.memory.data_mut(&mut self.store);
+        mem[1..1 + message.len()].copy_from_slice(message);
+        self.backend.call(&mut self.store, ())?;
+        let chan = self.get_channel.call(&mut self.store, ())?;
+        if chan <= 0 {
+            return Err(anyhow!("unsupported channel"));
+        }
+        let out_len = self.interactive_read.call(&mut self.store, ())? as usize;
+        let start = message.len() + 2;
+        let end = start + out_len;
+        let mem = self.memory.data(&self.store);
+        Ok(mem[start..end].to_vec())
+    }
+
+    /// Perform the initial startup handshake.
+    pub fn startup(&mut self) -> Result<()> {
+        let mut buf = BytesMut::new();
+        let params = [("user", "postgres"), ("database", "postgres")];
+        frontend::startup_message(params.iter().copied(), &mut buf)?;
+        let resp = self.exec_protocol(&buf)?;
+        let mut bytes = BytesMut::from(resp.as_slice());
+        while let Some(msg) = backend::Message::parse(&mut bytes)? {
+            if matches!(msg, backend::Message::ReadyForQuery(_)) {
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    /// Execute a simple query and return backend messages.
+    pub fn simple_query(&mut self, sql: &str) -> Result<Vec<backend::Message>> {
+        let mut buf = BytesMut::new();
+        frontend::query(sql, &mut buf)?;
+        let resp = self.exec_protocol(&buf)?;
+        let mut bytes = BytesMut::from(resp.as_slice());
+        let mut messages = Vec::new();
+        while let Some(msg) = backend::Message::parse(&mut bytes)? {
+            if matches!(msg, backend::Message::ReadyForQuery(_)) {
+                messages.push(msg);
+                break;
+            }
+            messages.push(msg);
+        }
+        Ok(messages)
+    }
+
+    /// Shutdown the backend and flush the filesystem.
+    pub fn shutdown(&mut self) -> Result<()> {
+        self.shutdown_fn.call(&mut self.store, ())?;
+        Ok(())
+    }
+}
+
+/// Evaluate the first column of the first row for truthiness.
+///
+/// Supported types:
+/// * text values "t" or "true" (case-insensitive)
+/// * numeric strings, non-zero is treated as `true`
+pub fn assert_row_true(row: &backend::DataRowBody) -> Result<bool> {
+    let mut fields = row.ranges();
+    if let Some(Some(range)) = fields.next()? {
+        let buf = row.buffer();
+        let val = &buf[range];
+        if let Ok(s) = std::str::from_utf8(val) {
+            if s.eq_ignore_ascii_case("t") || s.eq_ignore_ascii_case("true") {
+                return Ok(true);
+            }
+            if let Ok(n) = s.parse::<i64>() {
+                return Ok(n != 0);
+            }
+        }
+    }
+    Ok(false)
+}

--- a/justfile
+++ b/justfile
@@ -1,11 +1,8 @@
 set shell := ["bash", "-cu"]
 
-# Download the PGlite runtime artifacts
+# Download the PGlite runtime artifacts via the crate's helper
 pglite-assets:
-  set -euo pipefail
-  mkdir -p vendor/pglite
-  curl -L -o vendor/pglite/pglite.wasm https://cdn.jsdelivr.net/npm/@electric-sql/pglite/dist/pglite.wasm
-  curl -L -o vendor/pglite/pglite.data https://cdn.jsdelivr.net/npm/@electric-sql/pglite/dist/pglite.data
+  just --justfile crates/pglite/justfile pglite-assets
 
 # Run the example test against a local Postgres started via Docker Compose
 # Usage:

--- a/src/test_runner/pglite.rs
+++ b/src/test_runner/pglite.rs
@@ -1,159 +1,19 @@
-use anyhow::{anyhow, Result};
-use bytes::BytesMut;
-use fallible_iterator::FallibleIterator;
-use postgres_protocol::message::{backend, frontend};
+use anyhow::Result;
+use postgres_protocol::message::backend;
 use std::collections::HashSet;
-use wasmtime::{Engine, Instance, Linker, Memory, Module, Store, TypedFunc};
-use wasmtime_wasi::{preview1::{add_to_linker_sync, WasiP1Ctx}, DirPerms, FilePerms, WasiCtxBuilder};
 
 use super::{TestBackend, TestResult, TestSummary};
 use crate::ir::Config;
+use pglite::assert_row_true;
 
-/// In-memory Postgres backend powered by the PGlite WASM build.
-///
-/// This backend bootstraps a WASI environment, instantiates the
-/// pre-built `pglite.wasm` module and exposes a minimal wrapper
-/// around the exported functions required to initialise, run and
-/// shutdown the in-memory database. Query execution through the
-/// Postgres wire protocol is handled via an in-memory bridge.
-pub struct PGliteRuntime {
-    store: Store<WasiP1Ctx>,
-    _instance: Instance,
-    memory: Memory,
-    interactive_write: TypedFunc<i32, ()>,
-    interactive_read: TypedFunc<(), i32>,
-    get_channel: TypedFunc<(), i32>,
-    use_wire: TypedFunc<i32, ()>,
-    backend: TypedFunc<(), ()>,
-    shutdown_fn: TypedFunc<(), ()>,
-}
+pub use pglite::PGliteRuntime;
 
-impl PGliteRuntime {
-    /// Load the PGlite module and initialise the database files.
-    pub fn new() -> Result<Self> {
-        // Locate the bundled wasm and data files
-        let wasm_path = "vendor/pglite/pglite.wasm";
-
-        let engine = Engine::default();
-        let module = Module::from_file(&engine, wasm_path)?;
-        let mut linker = Linker::new(&engine);
-        // Minimal host env required by the PGlite module
-        linker.func_wrap("env", "invoke_iii", |_a: i32, _b: i32, _c: i32| -> i32 { 0 })?;
-        add_to_linker_sync(&mut linker, |ctx: &mut WasiP1Ctx| ctx)?;
-
-        // Preopen the directory containing pglite.data as /tmp/pglite
-        let mut builder = WasiCtxBuilder::new();
-        builder
-            .inherit_stdio()
-            .preopened_dir(
-                "vendor/pglite",
-                "/tmp/pglite",
-                DirPerms::all(),
-                FilePerms::all(),
-            )?;
-        let wasi = builder.build_p1();
-        let mut store = Store::new(&engine, wasi);
-        let instance = linker.instantiate(&mut store, &module)?;
-
-        // Call _pgl_initdb to ensure the database files are set up
-        let init = instance.get_typed_func::<(), i32>(&mut store, "_pgl_initdb")?;
-        let rc = init.call(&mut store, ())?;
-        if rc != 0 {
-            return Err(anyhow!("pglite initdb failed with code {rc}"));
-        }
-
-        let memory = instance
-            .get_memory(&mut store, "memory")
-            .ok_or_else(|| anyhow!("missing memory export"))?;
-        let interactive_write =
-            instance.get_typed_func::<i32, ()>(&mut store, "_interactive_write")?;
-        let interactive_read =
-            instance.get_typed_func::<(), i32>(&mut store, "_interactive_read")?;
-        let get_channel = instance.get_typed_func::<(), i32>(&mut store, "_get_channel")?;
-        let use_wire = instance.get_typed_func::<i32, ()>(&mut store, "_use_wire")?;
-        let backend = instance.get_typed_func::<(), ()>(&mut store, "_pgl_backend")?;
-        let shutdown_fn = instance.get_typed_func::<(), ()>(&mut store, "_pgl_shutdown")?;
-
-        Ok(Self {
-            store,
-            _instance: instance,
-            memory,
-            interactive_write,
-            interactive_read,
-            get_channel,
-            use_wire,
-            backend,
-            shutdown_fn,
-        })
-    }
-    /// Execute a single protocol message and return the backend response bytes.
-    fn exec_protocol(&mut self, message: &[u8]) -> Result<Vec<u8>> {
-        self.use_wire.call(&mut self.store, 1)?;
-        self.interactive_write
-            .call(&mut self.store, message.len() as i32)?;
-        let mem = self.memory.data_mut(&mut self.store);
-        mem[1..1 + message.len()].copy_from_slice(message);
-        self.backend.call(&mut self.store, ())?;
-        let chan = self.get_channel.call(&mut self.store, ())?;
-        if chan <= 0 {
-            return Err(anyhow!("unsupported channel"));
-        }
-        let out_len = self.interactive_read.call(&mut self.store, ())? as usize;
-        let start = message.len() + 2;
-        let end = start + out_len;
-        let mem = self.memory.data(&self.store);
-        Ok(mem[start..end].to_vec())
-    }
-
-    /// Perform the initial startup handshake.
-    pub fn startup(&mut self) -> Result<()> {
-        let mut buf = BytesMut::new();
-        let params = [("user", "postgres"), ("database", "postgres")];
-        frontend::startup_message(params.iter().copied(), &mut buf)?;
-        let resp = self.exec_protocol(&buf)?;
-        let mut bytes = BytesMut::from(resp.as_slice());
-        while let Some(msg) = backend::Message::parse(&mut bytes)? {
-            if matches!(msg, backend::Message::ReadyForQuery(_)) {
-                break;
-            }
-        }
-        Ok(())
-    }
-
-    /// Execute a simple query and return backend messages.
-    pub fn simple_query(&mut self, sql: &str) -> Result<Vec<backend::Message>> {
-        let mut buf = BytesMut::new();
-        frontend::query(sql, &mut buf)?;
-        let resp = self.exec_protocol(&buf)?;
-        let mut bytes = BytesMut::from(resp.as_slice());
-        let mut messages = Vec::new();
-        while let Some(msg) = backend::Message::parse(&mut bytes)? {
-            if matches!(msg, backend::Message::ReadyForQuery(_)) {
-                messages.push(msg);
-                break;
-            }
-            messages.push(msg);
-        }
-        Ok(messages)
-    }
-
-    /// Shutdown the backend and flush the filesystem.
-    pub fn shutdown(&mut self) -> Result<()> {
-        self.shutdown_fn.call(&mut self.store, ())?;
-        Ok(())
-    }
-}
-
+/// Test backend powered by the in-memory PGlite runtime.
 pub struct PGliteTestBackend;
 
 impl TestBackend for PGliteTestBackend {
-    fn run(
-        &self,
-        cfg: &Config,
-        _dsn: &str,
-        only: Option<&HashSet<String>>,
-    ) -> Result<TestSummary> {
-        let mut rt = PGliteRuntime::new()?;
+    fn run(&self, cfg: &Config, _dsn: &str, only: Option<&HashSet<String>>) -> Result<TestSummary> {
+        let mut rt = pglite::PGliteRuntime::new()?;
         rt.startup()?;
         let mut results = Vec::new();
         let mut passed = 0usize;
@@ -225,21 +85,3 @@ impl TestBackend for PGliteTestBackend {
         })
     }
 }
-
-fn assert_row_true(row: &backend::DataRowBody) -> Result<bool> {
-    let mut fields = row.ranges();
-    if let Some(Some(range)) = fields.next()? {
-        let buf = row.buffer();
-        let val = &buf[range];
-        if let Ok(s) = std::str::from_utf8(val) {
-            if s.eq_ignore_ascii_case("t") || s.eq_ignore_ascii_case("true") {
-                return Ok(true);
-            }
-            if let Ok(n) = s.parse::<i64>() {
-                return Ok(n != 0);
-            }
-        }
-    }
-    Ok(false)
-}
-


### PR DESCRIPTION
## Summary
- add crate-level justfile and README for downloading PGlite WASM assets
- delegate root justfile's asset task to the new crate helper
- fix missing host stubs in `PGliteRuntime` so REPL can start

## Testing
- `cargo test --features pglite`
- `cargo run --features pglite -- pglite`


------
https://chatgpt.com/codex/tasks/task_e_68b7131e0e508331942cd94cfa92978c