### PR TITLE
chore: pin pglite wasm via pnpm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 tmp_mig*
 vendor/pglite/
+node_modules/
 
 # Created by https://www.toptal.com/developers/gitignore/api/macos,windows,linux,rust
 # Edit at https://www.toptal.com/developers/gitignore?templates=macos,windows,linux,rust

--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ cargo build --release
 ### Optional: PGlite in-memory backend
 
 The PGlite runtime enables running tests without a real Postgres server. It is
-gated behind the `pglite` feature and requires downloading the WebAssembly
-artifacts:
+gated behind the `pglite` feature and requires installing the WebAssembly
+package:
 
 ```bash
-just pglite-assets        # download pglite.wasm and pglite.data
+just pglite-assets        # install @electric-sql/pglite into node_modules
 cargo build --features pglite
 ```
 

--- a/crates/pglite/README.md
+++ b/crates/pglite/README.md
@@ -7,7 +7,7 @@ WebAssembly.
 
 ## Setup
 
-Download the required WebAssembly artifacts with:
+Install the required WebAssembly package with:
 
 ```sh
 just --justfile crates/pglite/justfile pglite-assets
@@ -15,7 +15,8 @@ just --justfile crates/pglite/justfile pglite-assets
 just pglite-assets
 ```
 
-This fetches the `pglite.wasm` and `pglite.data` files into `vendor/pglite`.
+This runs `pnpm install`, placing `pglite.wasm` and `pglite.data` under
+`node_modules/@electric-sql/pglite/dist` for the runtime to load.
 
 ## Usage
 

--- a/crates/pglite/justfile
+++ b/crates/pglite/justfile
@@ -1,9 +1,5 @@
 set shell := ["bash", "-cu"]
-root := `git rev-parse --show-toplevel`
 
-# Download the PGlite WASM artifacts
+# Install the PGlite WASM package
 pglite-assets:
-  set -euo pipefail
-  mkdir -p {{root}}/vendor/pglite
-  curl -L -o {{root}}/vendor/pglite/pglite.wasm https://cdn.jsdelivr.net/npm/@electric-sql/pglite/dist/pglite.wasm
-  curl -L -o {{root}}/vendor/pglite/pglite.data https://cdn.jsdelivr.net/npm/@electric-sql/pglite/dist/pglite.data
+  pnpm install --frozen-lockfile

--- a/crates/pglite/package.json
+++ b/crates/pglite/package.json
@@ -1,0 +1,5 @@
+{
+	"dependencies": {
+		"@electric-sql/pglite": "0.3.7"
+	}
+}

--- a/crates/pglite/pnpm-lock.yaml
+++ b/crates/pglite/pnpm-lock.yaml
@@ -1,0 +1,22 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@electric-sql/pglite':
+        specifier: 0.3.7
+        version: 0.3.7
+
+packages:
+
+  '@electric-sql/pglite@0.3.7':
+    resolution: {integrity: sha512-5c3mybVrhxu5s47zFZtIGdG8YHkKCBENOmqxnNBjY53ZoDhADY/c5UqBDl159b7qtkzNPtbbb893wL9zi1kAuw==}
+
+snapshots:
+
+  '@electric-sql/pglite@0.3.7': {}


### PR DESCRIPTION
## Summary
- pin `@electric-sql/pglite` via package.json and lock file
- load wasm from `node_modules` and simplify asset installer
- document pnpm workflow for pglite

## Testing
- `pnpm install --frozen-lockfile`
- `cargo -Znext-lockfile-bump test` *(fails: package `zerotrie v0.2.2` requires rustc 1.82 or newer)*

------
https://chatgpt.com/codex/tasks/task_e_68b71c753a0c83319c25890f94f96bca