### PR TITLE
Add HCL formatting command

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ test_backend = "pglite"
 
 ## Usage
 
+- Format HCL files: `./target/release/dbschema fmt [path]`
 - Validate: `./target/release/dbschema --input examples/main.hcl validate`
 - Create migration (Postgres SQL): `./target/release/dbschema --input examples/main.hcl create-migration --out-dir migrations --name triggers`
 - Create Prisma models/enums only (no generator/datasource): `./target/release/dbschema --backend prisma --input examples/main.hcl create-migration --out-dir prisma --name schema`

--- a/justfile
+++ b/justfile
@@ -4,6 +4,10 @@ set shell := ["bash", "-cu"]
 pglite-assets:
   just --justfile crates/pglite/justfile pglite-assets
 
+# Format HCL files in place
+fmt *paths:
+  cargo run -- fmt {{paths}}
+
 # Run the example test against a local Postgres started via Docker Compose
 # Usage:
 #   just example-test                       # uses default DSN


### PR DESCRIPTION
## Summary
- add `dbschema fmt` subcommand to format HCL files/directories
- expose formatter via `fmt` recipe in justfile
- document formatting command in README

## Testing
- `cargo fmt -- --check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b72467cde0833194632dec5451c2eb