### PR TITLE
Add role and grant support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Prisma ORM support custom migrations, so you can use this tool to generate an SQ
    - `trigger`
    - `extension`
    - `policy`
+   - `role`
+   - `grant`
    - `module`
    - `output`
    - `test`
@@ -203,6 +205,19 @@ policy "<name>" {
   roles   = ["app_user"]       # optional: omit for PUBLIC
   using   = "email is not null"# optional: USING (...) predicate
   check   = null               # optional: WITH CHECK (...) predicate
+}
+
+role "<name>" {
+  name  = "<new_name>"  # optional, overrides the block name
+  login = true           # optional, default false
+}
+
+grant "<name>" {
+  role       = "app_user"           # grantee role (required)
+  schema     = "public"             # optional, default "public"
+  table      = "users"              # optional table target
+  function   = null                  # optional function target
+  privileges = ["SELECT"]          # required privileges
 }
 
 view "<name>" {

--- a/src/backends/postgres.rs
+++ b/src/backends/postgres.rs
@@ -19,6 +19,10 @@ impl Backend for PostgresBackend {
 fn to_sql(cfg: &Config) -> Result<String> {
     let mut out = String::new();
 
+    for r in &cfg.roles {
+        out.push_str(&format!("{}\n\n", pg::Role::from(r)));
+    }
+
     for s in &cfg.schemas {
         out.push_str(&format!("{}\n\n", pg::Schema::from(s)));
     }
@@ -56,6 +60,10 @@ fn to_sql(cfg: &Config) -> Result<String> {
 
     for t in &cfg.triggers {
         out.push_str(&format!("{}\n\n", pg::Trigger::from(t)));
+    }
+
+    for g in &cfg.grants {
+        out.push_str(&format!("{}\n\n", pg::Grant::from(g)));
     }
 
     Ok(out)

--- a/src/config.rs
+++ b/src/config.rs
@@ -82,6 +82,8 @@ pub enum ResourceKind {
     Triggers,
     Extensions,
     Policies,
+    Roles,
+    Grants,
     Tests,
 }
 
@@ -97,6 +99,8 @@ impl fmt::Display for ResourceKind {
             ResourceKind::Triggers => "triggers",
             ResourceKind::Extensions => "extensions",
             ResourceKind::Policies => "policies",
+            ResourceKind::Roles => "roles",
+            ResourceKind::Grants => "grants",
             ResourceKind::Tests => "tests",
         };
         write!(f, "{}", s)
@@ -117,6 +121,8 @@ impl std::str::FromStr for ResourceKind {
             "triggers" => Ok(ResourceKind::Triggers),
             "extensions" => Ok(ResourceKind::Extensions),
             "policies" => Ok(ResourceKind::Policies),
+            "roles" => Ok(ResourceKind::Roles),
+            "grants" => Ok(ResourceKind::Grants),
             "tests" => Ok(ResourceKind::Tests),
             _ => Err(format!("invalid resource kind: {}", s)),
         }
@@ -138,6 +144,8 @@ impl TargetConfig {
                 ResourceKind::Triggers,
                 ResourceKind::Extensions,
                 ResourceKind::Policies,
+                ResourceKind::Roles,
+                ResourceKind::Grants,
                 ResourceKind::Tests,
             ]
             .into_iter()
@@ -203,7 +211,7 @@ mod tests {
         let include_set = target.get_include_set();
         assert!(include_set.contains(&ResourceKind::Tables));
         assert!(include_set.contains(&ResourceKind::Enums));
-        assert_eq!(include_set.len(), 10); // All resource types
+        assert_eq!(include_set.len(), 12); // All resource types
     }
 
     #[test]

--- a/src/frontend/ast/mod.rs
+++ b/src/frontend/ast/mod.rs
@@ -11,6 +11,8 @@ pub struct Config {
     pub views: Vec<AstView>,
     pub materialized: Vec<AstMaterializedView>,
     pub policies: Vec<AstPolicy>,
+    pub roles: Vec<AstRole>,
+    pub grants: Vec<AstGrant>,
     pub tests: Vec<AstTest>,
     pub outputs: Vec<AstOutput>,
 }
@@ -95,6 +97,23 @@ pub struct AstPolicy {
     pub roles: Vec<String>,
     pub using: Option<String>,
     pub check: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AstRole {
+    pub name: String,
+    pub alt_name: Option<String>,
+    pub login: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct AstGrant {
+    pub name: String,
+    pub role: String,
+    pub privileges: Vec<String>,
+    pub schema: Option<String>,
+    pub table: Option<String>,
+    pub function: Option<String>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/frontend/core.rs
+++ b/src/frontend/core.rs
@@ -569,6 +569,8 @@ fn load_file(
             cfg.views.extend(sub.views);
             cfg.materialized.extend(sub.materialized);
             cfg.policies.extend(sub.policies);
+            cfg.roles.extend(sub.roles);
+            cfg.grants.extend(sub.grants);
         }
     }
 
@@ -677,6 +679,28 @@ fn load_file(
             .to_string();
         let for_each_expr = find_attr(blk.body(), "for_each");
         execute_for_each::<ast::AstEnum>(&name, blk.body(), &env, &mut cfg, for_each_expr)?;
+    }
+
+    for blk in body.blocks().filter(|b| b.identifier() == "role") {
+        let name = blk
+            .labels()
+            .get(0)
+            .ok_or_else(|| anyhow::anyhow!("role block missing name label"))?
+            .as_str()
+            .to_string();
+        let for_each_expr = find_attr(blk.body(), "for_each");
+        execute_for_each::<ast::AstRole>(&name, blk.body(), &env, &mut cfg, for_each_expr)?;
+    }
+
+    for blk in body.blocks().filter(|b| b.identifier() == "grant") {
+        let name = blk
+            .labels()
+            .get(0)
+            .ok_or_else(|| anyhow::anyhow!("grant block missing name label"))?
+            .as_str()
+            .to_string();
+        let for_each_expr = find_attr(blk.body(), "for_each");
+        execute_for_each::<ast::AstGrant>(&name, blk.body(), &env, &mut cfg, for_each_expr)?;
     }
 
     for blk in body.blocks().filter(|b| b.identifier() == "test") {

--- a/src/frontend/lower.rs
+++ b/src/frontend/lower.rs
@@ -12,6 +12,8 @@ pub fn lower_config(ast: ast::Config) -> ir::Config {
         views: ast.views.into_iter().map(Into::into).collect(),
         materialized: ast.materialized.into_iter().map(Into::into).collect(),
         policies: ast.policies.into_iter().map(Into::into).collect(),
+        roles: ast.roles.into_iter().map(Into::into).collect(),
+        grants: ast.grants.into_iter().map(Into::into).collect(),
         tests: ast.tests.into_iter().map(Into::into).collect(),
         outputs: ast.outputs.into_iter().map(Into::into).collect(),
     }
@@ -123,6 +125,29 @@ impl From<ast::AstPolicy> for ir::PolicySpec {
     }
 }
 
+impl From<ast::AstRole> for ir::RoleSpec {
+    fn from(r: ast::AstRole) -> Self {
+        Self {
+            name: r.name,
+            alt_name: r.alt_name,
+            login: r.login,
+        }
+    }
+}
+
+impl From<ast::AstGrant> for ir::GrantSpec {
+    fn from(g: ast::AstGrant) -> Self {
+        Self {
+            name: g.name,
+            role: g.role,
+            privileges: g.privileges,
+            schema: g.schema,
+            table: g.table,
+            function: g.function,
+        }
+    }
+}
+
 impl From<ast::AstTable> for ir::TableSpec {
     fn from(t: ast::AstTable) -> Self {
         Self {
@@ -213,4 +238,3 @@ impl From<ast::AstOutput> for ir::OutputSpec {
         }
     }
 }
-

--- a/src/ir/config.rs
+++ b/src/ir/config.rs
@@ -12,6 +12,8 @@ pub struct Config {
     pub views: Vec<ViewSpec>,
     pub materialized: Vec<MaterializedViewSpec>,
     pub policies: Vec<PolicySpec>,
+    pub roles: Vec<RoleSpec>,
+    pub grants: Vec<GrantSpec>,
     pub tests: Vec<TestSpec>,
     pub outputs: Vec<OutputSpec>,
 }
@@ -96,6 +98,23 @@ pub struct PolicySpec {
     pub roles: Vec<String>,    // empty => PUBLIC (omit TO clause)
     pub using: Option<String>, // USING (expr)
     pub check: Option<String>, // WITH CHECK (expr)
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RoleSpec {
+    pub name: String,
+    pub alt_name: Option<String>,
+    pub login: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GrantSpec {
+    pub name: String,
+    pub role: String,
+    pub privileges: Vec<String>,
+    pub schema: Option<String>,
+    pub table: Option<String>,
+    pub function: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -2,6 +2,6 @@ pub mod config;
 
 pub use config::{
     BackReferenceSpec, ColumnSpec, Config, EnumSpec, ExtensionSpec, ForeignKeySpec, FunctionSpec,
-    IndexSpec, MaterializedViewSpec, OutputSpec, PolicySpec, PrimaryKeySpec, SchemaSpec, TableSpec,
-    TestSpec, TriggerSpec, ViewSpec,
+    GrantSpec, IndexSpec, MaterializedViewSpec, OutputSpec, PolicySpec, PrimaryKeySpec, RoleSpec,
+    SchemaSpec, TableSpec, TestSpec, TriggerSpec, ViewSpec,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,8 +14,8 @@ use std::path::Path;
 // Public re-exports
 use crate::frontend::env::EnvVars;
 pub use ir::{
-    Config, EnumSpec, ExtensionSpec, FunctionSpec, MaterializedViewSpec, OutputSpec, PolicySpec,
-    SchemaSpec, TableSpec, TriggerSpec, ViewSpec,
+    Config, EnumSpec, ExtensionSpec, FunctionSpec, GrantSpec, MaterializedViewSpec, OutputSpec,
+    PolicySpec, RoleSpec, SchemaSpec, TableSpec, TriggerSpec, ViewSpec,
 };
 
 // Loader abstraction: lets callers control how files are read.
@@ -57,6 +57,8 @@ where
         views: maybe!(Views, views),
         materialized: maybe!(Materialized, materialized),
         policies: maybe!(Policies, policies),
+        roles: maybe!(Roles, roles),
+        grants: maybe!(Grants, grants),
         tests: maybe!(Tests, tests),
         outputs: cfg.outputs.clone(),
         ..Default::default()

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,17 @@
 use anyhow::{anyhow, Context, Result};
 use clap::{Parser, Subcommand, ValueEnum};
 use dbschema::frontend::env::EnvVars;
-#[cfg(feature = "pglite")]
-use postgres_protocol::message::backend;
-#[cfg(feature = "pglite")]
-use fallible_iterator::FallibleIterator;
 use dbschema::test_runner::TestBackend;
 use dbschema::{
     apply_filters,
     config::{self, Config as DbschemaConfig, ResourceKind, TargetConfig},
     load_config, validate, Loader, OutputSpec,
 };
+#[cfg(feature = "pglite")]
+use fallible_iterator::FallibleIterator;
 use log::{error, info};
+#[cfg(feature = "pglite")]
+use postgres_protocol::message::backend;
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -202,7 +202,11 @@ fn main() -> Result<()> {
                 }
                 print_outputs(&filtered.outputs);
             }
-            Commands::Test { dsn, names, backend } => {
+            Commands::Test {
+                dsn,
+                names,
+                backend,
+            } => {
                 let (dsn, backend, config) = if cli.config {
                     let dbschema_config = config::load_config()
                         .with_context(|| "failed to load dbschema.toml")?

--- a/src/passes/validate.rs
+++ b/src/passes/validate.rs
@@ -1,6 +1,5 @@
 use anyhow::{bail, Result};
 
-
 use crate::ir::{Config, EnumSpec};
 
 pub fn validate(cfg: &Config, strict: bool) -> Result<()> {
@@ -27,11 +26,8 @@ pub fn validate(cfg: &Config, strict: bool) -> Result<()> {
             for column in &table.columns {
                 // Check if column type is an enum and if it's defined in HCL
                 if is_likely_enum(&column.r#type) {
-                    let found_enum = find_enum_for_type(
-                        &cfg.enums,
-                        &column.r#type,
-                        table.schema.as_deref(),
-                    );
+                    let found_enum =
+                        find_enum_for_type(&cfg.enums, &column.r#type, table.schema.as_deref());
                     if found_enum.is_none() {
                         bail!("Strict mode: Enum type '{}' referenced in table '{}' column '{}' is not defined in HCL", column.r#type, table.name, column.name);
                     }

--- a/src/test_runner/mod.rs
+++ b/src/test_runner/mod.rs
@@ -3,9 +3,9 @@ use std::collections::HashSet;
 
 use crate::ir::Config;
 
-pub mod postgres;
 #[cfg(feature = "pglite")]
 pub mod pglite;
+pub mod postgres;
 
 pub struct TestResult {
     pub name: String,

--- a/tests/pglite_backend.rs
+++ b/tests/pglite_backend.rs
@@ -1,11 +1,11 @@
 #[cfg(feature = "pglite")]
-use dbschema::test_runner::{pglite::PGliteTestBackend, TestBackend};
-#[cfg(feature = "pglite")]
-use dbschema::{load_config, Loader};
+use anyhow::Result;
 #[cfg(feature = "pglite")]
 use dbschema::frontend::env::EnvVars;
 #[cfg(feature = "pglite")]
-use anyhow::Result;
+use dbschema::test_runner::{pglite::PGliteTestBackend, TestBackend};
+#[cfg(feature = "pglite")]
+use dbschema::{load_config, Loader};
 #[cfg(feature = "pglite")]
 use std::collections::HashMap;
 #[cfg(feature = "pglite")]
@@ -40,12 +40,16 @@ fn pglite_backend_runs_test() -> Result<()> {
     )?;
 
     let loader = FsLoader;
-    let cfg = load_config(&hcl_path, &loader, EnvVars {
-        vars: HashMap::new(),
-        locals: HashMap::new(),
-        modules: HashMap::new(),
-        each: None,
-    })?;
+    let cfg = load_config(
+        &hcl_path,
+        &loader,
+        EnvVars {
+            vars: HashMap::new(),
+            locals: HashMap::new(),
+            modules: HashMap::new(),
+            each: None,
+        },
+    )?;
 
     let backend = PGliteTestBackend;
     let summary = backend.run(&cfg, "pglite", None)?;


### PR DESCRIPTION
## Summary
- parse new `role` and `grant` blocks
- model roles and grants in IR and Postgres SQL generation
- document roles and grants in README

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b723ffb9c08331b74897b31b299e22