### PR TITLE
Add sequence resource support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Prisma ORM support custom migrations, so you can use this tool to generate an SQ
    - `locals`
    - `schema`
    - `enum`
+   - `sequence`
    - `table`
    - `view`
    - `materialized`
@@ -185,6 +186,20 @@ enum "<name>" {
   values = ["a", "b"]  # required
 }
 
+sequence "<name>" {
+  name        = "<new_name>"   # optional, overrides the block name
+  schema      = "public"       # optional, default "public"
+  if_not_exists = true          # optional, default true
+  as          = "bigint"       # optional
+  increment   = 1               # optional
+  min_value   = 1               # optional
+  max_value   = null            # optional
+  start       = 1               # optional
+  cache       = 1               # optional
+  cycle       = false           # optional
+  owned_by    = "table.column" # optional
+}
+
 trigger "<name>" {
   name     = "<new_name>"     # optional, overrides the block name
   schema     = "public"        # optional, default "public"
@@ -288,7 +303,7 @@ module "<name>" {
 - Control which resources are included per run:
   - `--include tables --include functions` (repeatable)
   - `--exclude tables` (repeatable)
-  - Resource kinds: `schemas, enums, tables, views, materialized, functions, triggers, extensions, policies, tests`
+  - Resource kinds: `schemas, sequences, enums, tables, views, materialized, functions, triggers, extensions, policies, tests`
 - Example split-output workflow:
   - Prisma models for tables: `dbschema --backend prisma --include tables --input examples/main.hcl create-migration --out-dir prisma --name schema`
   - SQL for everything else: `dbschema --backend postgres --exclude tables --input examples/main.hcl create-migration --out-dir migrations --name non_tables`

--- a/dbschema.toml
+++ b/dbschema.toml
@@ -19,7 +19,7 @@ input = "main.hcl"
 output = "schema.sql"
 
 # Include/exclude filters
-include = ["schemas", "tables", "views", "functions", "triggers", "extensions", "policies"]
+include = ["schemas", "sequences", "tables", "views", "functions", "triggers", "extensions", "policies"]
 exclude = []
 
 # Variables for this target
@@ -47,7 +47,7 @@ input = "main.hcl"
 output = "docs/schema.json"
 
 # Include everything for documentation
-include = ["schemas", "enums", "tables", "views", "materialized", "functions", "triggers", "extensions", "policies", "tests"]
+include = ["schemas", "sequences", "enums", "tables", "views", "materialized", "functions", "triggers", "extensions", "policies", "tests"]
 exclude = []
 
 # Documentation-specific variables
@@ -61,7 +61,7 @@ input = "main.hcl"
 output = "test_schema.sql"
 
 # Include test resources
-include = ["schemas", "tables", "functions", "triggers", "tests"]
+include = ["schemas", "sequences", "tables", "functions", "triggers", "tests"]
 exclude = ["extensions", "policies"]
 
 # Test-specific variables

--- a/examples/sequence.hcl
+++ b/examples/sequence.hcl
@@ -1,0 +1,10 @@
+sequence "user_id_seq" {
+  schema = "public"
+  as = "bigint"
+  increment = 1
+  min_value = 1
+  start = 1
+  cache = 1
+  cycle = false
+  owned_by = "users.id"
+}

--- a/src/backends/postgres.rs
+++ b/src/backends/postgres.rs
@@ -31,6 +31,10 @@ fn to_sql(cfg: &Config) -> Result<String> {
         out.push_str(&format!("{}\n\n", pg::Extension::from(e)));
     }
 
+    for s in &cfg.sequences {
+        out.push_str(&format!("{}\n\n", pg::Sequence::from(s)));
+    }
+
     for e in &cfg.enums {
         out.push_str(&format!("{}\n\n", pg::Enum::from(e)));
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -81,6 +81,7 @@ pub enum ResourceKind {
     Functions,
     Triggers,
     Extensions,
+    Sequences,
     Policies,
     Roles,
     Grants,
@@ -98,6 +99,7 @@ impl fmt::Display for ResourceKind {
             ResourceKind::Functions => "functions",
             ResourceKind::Triggers => "triggers",
             ResourceKind::Extensions => "extensions",
+            ResourceKind::Sequences => "sequences",
             ResourceKind::Policies => "policies",
             ResourceKind::Roles => "roles",
             ResourceKind::Grants => "grants",
@@ -120,6 +122,7 @@ impl std::str::FromStr for ResourceKind {
             "functions" => Ok(ResourceKind::Functions),
             "triggers" => Ok(ResourceKind::Triggers),
             "extensions" => Ok(ResourceKind::Extensions),
+            "sequences" => Ok(ResourceKind::Sequences),
             "policies" => Ok(ResourceKind::Policies),
             "roles" => Ok(ResourceKind::Roles),
             "grants" => Ok(ResourceKind::Grants),
@@ -143,6 +146,7 @@ impl TargetConfig {
                 ResourceKind::Functions,
                 ResourceKind::Triggers,
                 ResourceKind::Extensions,
+                ResourceKind::Sequences,
                 ResourceKind::Policies,
                 ResourceKind::Roles,
                 ResourceKind::Grants,
@@ -211,7 +215,7 @@ mod tests {
         let include_set = target.get_include_set();
         assert!(include_set.contains(&ResourceKind::Tables));
         assert!(include_set.contains(&ResourceKind::Enums));
-        assert_eq!(include_set.len(), 12); // All resource types
+        assert_eq!(include_set.len(), 13); // All resource types
     }
 
     #[test]

--- a/src/frontend/ast/mod.rs
+++ b/src/frontend/ast/mod.rs
@@ -5,6 +5,7 @@ pub struct Config {
     pub functions: Vec<AstFunction>,
     pub triggers: Vec<AstTrigger>,
     pub extensions: Vec<AstExtension>,
+    pub sequences: Vec<AstSequence>,
     pub schemas: Vec<AstSchema>,
     pub enums: Vec<AstEnum>,
     pub tables: Vec<AstTable>,
@@ -50,6 +51,22 @@ pub struct AstExtension {
     pub if_not_exists: bool,
     pub schema: Option<String>,
     pub version: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AstSequence {
+    pub name: String,
+    pub alt_name: Option<String>,
+    pub schema: Option<String>,
+    pub if_not_exists: bool,
+    pub r#as: Option<String>,
+    pub increment: Option<i64>,
+    pub min_value: Option<i64>,
+    pub max_value: Option<i64>,
+    pub start: Option<i64>,
+    pub cache: Option<i64>,
+    pub cycle: bool,
+    pub owned_by: Option<String>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/frontend/core.rs
+++ b/src/frontend/core.rs
@@ -515,6 +515,7 @@ fn load_file(
                 cfg.functions.extend(sub.functions);
                 cfg.triggers.extend(sub.triggers);
                 cfg.extensions.extend(sub.extensions);
+                cfg.sequences.extend(sub.sequences);
                 cfg.tables.extend(sub.tables);
                 cfg.views.extend(sub.views);
                 cfg.materialized.extend(sub.materialized);
@@ -565,6 +566,7 @@ fn load_file(
             cfg.functions.extend(sub.functions);
             cfg.triggers.extend(sub.triggers);
             cfg.extensions.extend(sub.extensions);
+            cfg.sequences.extend(sub.sequences);
             cfg.tables.extend(sub.tables);
             cfg.views.extend(sub.views);
             cfg.materialized.extend(sub.materialized);
@@ -585,6 +587,17 @@ fn load_file(
             .to_string();
         let for_each_expr = find_attr(blk.body(), "for_each");
         execute_for_each::<ast::AstSchema>(&name, blk.body(), &env, &mut cfg, for_each_expr)?;
+    }
+
+    for blk in body.blocks().filter(|b| b.identifier() == "sequence") {
+        let name = blk
+            .labels()
+            .get(0)
+            .ok_or_else(|| anyhow::anyhow!("sequence block missing name label"))?
+            .as_str()
+            .to_string();
+        let for_each_expr = find_attr(blk.body(), "for_each");
+        execute_for_each::<ast::AstSequence>(&name, blk.body(), &env, &mut cfg, for_each_expr)?;
     }
 
     for blk in body.blocks().filter(|b| b.identifier() == "table") {

--- a/src/frontend/lower.rs
+++ b/src/frontend/lower.rs
@@ -6,6 +6,7 @@ pub fn lower_config(ast: ast::Config) -> ir::Config {
         functions: ast.functions.into_iter().map(Into::into).collect(),
         triggers: ast.triggers.into_iter().map(Into::into).collect(),
         extensions: ast.extensions.into_iter().map(Into::into).collect(),
+        sequences: ast.sequences.into_iter().map(Into::into).collect(),
         schemas: ast.schemas.into_iter().map(Into::into).collect(),
         enums: ast.enums.into_iter().map(Into::into).collect(),
         tables: ast.tables.into_iter().map(Into::into).collect(),
@@ -59,6 +60,25 @@ impl From<ast::AstExtension> for ir::ExtensionSpec {
             if_not_exists: e.if_not_exists,
             schema: e.schema,
             version: e.version,
+        }
+    }
+}
+
+impl From<ast::AstSequence> for ir::SequenceSpec {
+    fn from(s: ast::AstSequence) -> Self {
+        Self {
+            name: s.name,
+            alt_name: s.alt_name,
+            schema: s.schema,
+            if_not_exists: s.if_not_exists,
+            r#as: s.r#as,
+            increment: s.increment,
+            min_value: s.min_value,
+            max_value: s.max_value,
+            start: s.start,
+            cache: s.cache,
+            cycle: s.cycle,
+            owned_by: s.owned_by,
         }
     }
 }

--- a/src/ir/config.rs
+++ b/src/ir/config.rs
@@ -6,6 +6,7 @@ pub struct Config {
     pub functions: Vec<FunctionSpec>,
     pub triggers: Vec<TriggerSpec>,
     pub extensions: Vec<ExtensionSpec>,
+    pub sequences: Vec<SequenceSpec>,
     pub schemas: Vec<SchemaSpec>,
     pub enums: Vec<EnumSpec>,
     pub tables: Vec<TableSpec>,
@@ -51,6 +52,22 @@ pub struct ExtensionSpec {
     pub if_not_exists: bool,
     pub schema: Option<String>,
     pub version: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SequenceSpec {
+    pub name: String,
+    pub alt_name: Option<String>,
+    pub schema: Option<String>,
+    pub if_not_exists: bool,
+    pub r#as: Option<String>,
+    pub increment: Option<i64>,
+    pub min_value: Option<i64>,
+    pub max_value: Option<i64>,
+    pub start: Option<i64>,
+    pub cache: Option<i64>,
+    pub cycle: bool,
+    pub owned_by: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -3,5 +3,5 @@ pub mod config;
 pub use config::{
     BackReferenceSpec, ColumnSpec, Config, EnumSpec, ExtensionSpec, ForeignKeySpec, FunctionSpec,
     GrantSpec, IndexSpec, MaterializedViewSpec, OutputSpec, PolicySpec, PrimaryKeySpec, RoleSpec,
-    SchemaSpec, TableSpec, TestSpec, TriggerSpec, ViewSpec,
+    SchemaSpec, SequenceSpec, TableSpec, TestSpec, TriggerSpec, ViewSpec,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ use std::path::Path;
 use crate::frontend::env::EnvVars;
 pub use ir::{
     Config, EnumSpec, ExtensionSpec, FunctionSpec, GrantSpec, MaterializedViewSpec, OutputSpec,
-    PolicySpec, RoleSpec, SchemaSpec, TableSpec, TriggerSpec, ViewSpec,
+    PolicySpec, RoleSpec, SchemaSpec, SequenceSpec, TableSpec, TriggerSpec, ViewSpec,
 };
 
 // Loader abstraction: lets callers control how files are read.
@@ -51,6 +51,7 @@ where
         functions: maybe!(Functions, functions),
         triggers: maybe!(Triggers, triggers),
         extensions: maybe!(Extensions, extensions),
+        sequences: maybe!(Sequences, sequences),
         schemas: maybe!(Schemas, schemas),
         enums: maybe!(Enums, enums),
         tables: maybe!(Tables, tables),

--- a/src/main.rs
+++ b/src/main.rs
@@ -596,6 +596,7 @@ fn cli_filter_sets(
             R::Functions,
             R::Triggers,
             R::Extensions,
+            R::Sequences,
             R::Policies,
             R::Tests,
         ]


### PR DESCRIPTION
## Summary
- support `sequence` blocks in HCL via new AstSequence and SequenceSpec
- emit SQL for sequences with `CREATE SEQUENCE IF NOT EXISTS`
- document sequence usage and add example

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b7268d43fc83318e4615ed8ac4391f