### PR TITLE
Add count attribute support for block iteration

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Prisma ORM support custom migrations, so you can use this tool to generate an SQ
    - `test`
 
 - Variables via `--var key=value` and `--var-file`, with optional type and validation.
+- Block repetition with `for_each` (arrays/objects) or numeric `count`.
 - Dynamic blocks: replicate nested blocks with `dynamic "name" { for_each = ... content { ... } }`.
 - Modules: `module "name" { source = "./path" ... }`.
 - Full HCL expression support: numbers, booleans, arrays, objects, traversals (`var.*`, `local.*`), function calls, and `${...}` templates.
@@ -319,6 +320,7 @@ variable "count" {
 - Replicate blocks with `for_each` on the block (arrays or objects):
   - Arrays: `each.key` is the index (number), `each.value` is the element.
   - Objects: `each.key` is the object key (string), `each.value` is the value.
+- Repeat blocks with a numeric `count` on the block; reference the index via `count.index`.
 - Generate nested blocks with Terraform-style `dynamic` blocks:
   - Set `labels` to populate block labels when needed.
 - Example:
@@ -330,6 +332,21 @@ trigger "upd" {
   schema   = "public"
   for_each = var.tables       # will create two triggers
   table    = each.value       # "users" then "orders"
+  timing   = "BEFORE"
+  events   = ["UPDATE"]
+  level    = "ROW"
+  function = "set_updated_at"
+}
+```
+
+Using `count` to repeat a block a fixed number of times:
+
+```hcl
+trigger "upd" {
+  count    = 2
+  name     = "set_updated_at_${count.index}"
+  schema   = "public"
+  table    = "users"
   timing   = "BEFORE"
   events   = ["UPDATE"]
   level    = "ROW"

--- a/examples/count.hcl
+++ b/examples/count.hcl
@@ -1,0 +1,33 @@
+variable "schema" { default = "public" }
+
+function "f" {
+  schema   = var.schema
+  language = "plpgsql"
+  returns  = "trigger"
+  replace  = true
+  body = <<-SQL
+    BEGIN
+      RETURN NEW;
+    END;
+  SQL
+}
+
+table "users" {
+  schema = var.schema
+  column "id" { type = "int" }
+}
+
+trigger "upd" {
+  count    = 2
+  name     = "set_updated_at_${count.index}"
+  schema   = var.schema
+  table    = "users"
+  timing   = "BEFORE"
+  events   = ["UPDATE"]
+  level    = "ROW"
+  function = "f"
+}
+
+test "count_triggers" {
+  assert = "SELECT COUNT(*) = 2 FROM pg_trigger WHERE tgname LIKE 'set_updated_at_%'"
+}

--- a/src/frontend/core.rs
+++ b/src/frontend/core.rs
@@ -253,8 +253,25 @@ fn resolve_traversal_value(tr: &Traversal, env: &EnvVars) -> Result<Value> {
             }
             Ok(current)
         }
+        "count" => {
+            let Some(TraversalOperator::GetAttr(name)) = it.next() else {
+                bail!("expected count.index");
+            };
+            let idx = env
+                .count
+                .ok_or_else(|| anyhow::anyhow!("'count' is only available inside count iterations"))?;
+            match name.as_str() {
+                "index" => {
+                    if it.next().is_some() {
+                        bail!("count.index does not support further traversal");
+                    }
+                    Ok(Value::Number(Number::from(idx as u64)))
+                }
+                other => bail!("unsupported count attribute '{}': expected index", other),
+            }
+        }
         _ => bail!(
-            "unsupported traversal root '{}': expected var.*, local.*, module.*, or each.*",
+            "unsupported traversal root '{}': expected var.*, local.*, module.*, each.*, or count.*",
             root
         ),
     }
@@ -392,6 +409,10 @@ pub fn create_eval_context(env: &EnvVars) -> HclContext<'_> {
     if let Some((key, value)) = &env.each {
         ctx.declare_var("each_key", key.clone());
         ctx.declare_var("each_value", value.clone());
+    }
+
+    if let Some(index) = env.count {
+        ctx.declare_var("count_index", Value::Number(Number::from(index as u64)));
     }
 
     ctx
@@ -619,7 +640,15 @@ fn load_file(
         let source = get_attr_string(b, "source", &env)?
             .with_context(|| format!("module '{}' missing 'source'", label.as_str()))?;
         let module_path = resolve_module_path(base, &source)?;
-        if let Some(fe) = find_attr(b, "for_each") {
+        let for_each_attr = find_attr(b, "for_each");
+        let count_attr = find_attr(b, "count");
+        if for_each_attr.is_some() && count_attr.is_some() {
+            bail!(
+                "module '{}' cannot have both for_each and count",
+                label.as_str()
+            );
+        }
+        if let Some(fe) = for_each_attr {
             let coll = expr_to_value(fe.expr(), &env)?;
             crate::frontend::for_each::for_each_iter(&coll, &mut |k, v| {
                 let mut iter_env = env.clone();
@@ -627,7 +656,7 @@ fn load_file(
                 let mut mod_vars: HashMap<String, hcl::Value> = HashMap::new();
                 for attr in b.attributes() {
                     let k = attr.key();
-                    if k == "source" || k == "for_each" {
+                    if k == "source" || k == "for_each" || k == "count" {
                         continue;
                     }
                     let v = expr_to_value(attr.expr(), &iter_env).with_context(|| {
@@ -640,6 +669,7 @@ fn load_file(
                     locals: HashMap::new(),
                     modules: HashMap::new(),
                     each: None,
+                    count: None,
                 };
                 let sub = load_file(
                     loader,
@@ -667,12 +697,66 @@ fn load_file(
                 // Outputs from for_each modules aren't accessible via module.*
                 Ok(())
             })?;
+        } else if let Some(ce) = count_attr {
+            let val = expr_to_value(ce.expr(), &env)?;
+            let times = match val {
+                hcl::Value::Number(n) => n
+                    .as_u64()
+                    .ok_or_else(|| anyhow::anyhow!("count must be a non-negative integer"))?
+                    as usize,
+                other => bail!("count expects number, got {other:?}"),
+            };
+            for i in 0..times {
+                let mut iter_env = env.clone();
+                iter_env.count = Some(i);
+                let mut mod_vars: HashMap<String, hcl::Value> = HashMap::new();
+                for attr in b.attributes() {
+                    let k = attr.key();
+                    if k == "source" || k == "for_each" || k == "count" {
+                        continue;
+                    }
+                    let v = expr_to_value(attr.expr(), &iter_env).with_context(|| {
+                        format!("evaluating module var '{}.{}'", label.as_str(), k)
+                    })?;
+                    mod_vars.insert(k.to_string(), v);
+                }
+                let mod_env = EnvVars {
+                    vars: mod_vars,
+                    locals: HashMap::new(),
+                    modules: HashMap::new(),
+                    each: None,
+                    count: None,
+                };
+                let sub = load_file(
+                    loader,
+                    &module_path.join("main.hcl"),
+                    &module_path,
+                    &mod_env,
+                    visited,
+                )
+                .with_context(|| {
+                    format!(
+                        "loading module '{}' from {}",
+                        label.as_str(),
+                        module_path.display()
+                    )
+                })?;
+                cfg.schemas.extend(sub.schemas);
+                cfg.enums.extend(sub.enums);
+                cfg.functions.extend(sub.functions);
+                cfg.triggers.extend(sub.triggers);
+                cfg.extensions.extend(sub.extensions);
+                cfg.tables.extend(sub.tables);
+                cfg.views.extend(sub.views);
+                cfg.materialized.extend(sub.materialized);
+                cfg.policies.extend(sub.policies);
+            }
         } else {
-            // Prepare vars for module: start empty, collect its own defaults while loading; pass overrides from attrs (excluding 'source'/'for_each')
+            // Prepare vars for module: start empty, collect its own defaults while loading; pass overrides from attrs (excluding 'source'/'for_each'/'count')
             let mut mod_vars: HashMap<String, hcl::Value> = HashMap::new();
             for attr in b.attributes() {
                 let k = attr.key();
-                if k == "source" || k == "for_each" {
+                if k == "source" || k == "for_each" || k == "count" {
                     continue;
                 }
                 let v = expr_to_value(attr.expr(), &env)
@@ -684,6 +768,7 @@ fn load_file(
                 locals: HashMap::new(),
                 modules: HashMap::new(),
                 each: None,
+                count: None,
             };
             let sub = load_file(
                 loader,
@@ -729,7 +814,15 @@ fn load_file(
             .as_str()
             .to_string();
         let for_each_expr = find_attr(blk.body(), "for_each");
-        execute_for_each::<ast::AstSchema>(&name, blk.body(), &env, &mut cfg, for_each_expr)?;
+        let count_expr = find_attr(blk.body(), "count");
+        execute_for_each::<ast::AstSchema>(
+            &name,
+            blk.body(),
+            &env,
+            &mut cfg,
+            for_each_expr,
+            count_expr,
+        )?;
     }
 
     for blk in body.blocks().filter(|b| b.identifier() == "table") {
@@ -740,7 +833,15 @@ fn load_file(
             .as_str()
             .to_string();
         let for_each_expr = find_attr(blk.body(), "for_each");
-        execute_for_each::<ast::AstTable>(&name, blk.body(), &env, &mut cfg, for_each_expr)?;
+        let count_expr = find_attr(blk.body(), "count");
+        execute_for_each::<ast::AstTable>(
+            &name,
+            blk.body(),
+            &env,
+            &mut cfg,
+            for_each_expr,
+            count_expr,
+        )?;
     }
 
     for blk in body.blocks().filter(|b| b.identifier() == "view") {
@@ -751,7 +852,15 @@ fn load_file(
             .as_str()
             .to_string();
         let for_each_expr = find_attr(blk.body(), "for_each");
-        execute_for_each::<ast::AstView>(&name, blk.body(), &env, &mut cfg, for_each_expr)?;
+        let count_expr = find_attr(blk.body(), "count");
+        execute_for_each::<ast::AstView>(
+            &name,
+            blk.body(),
+            &env,
+            &mut cfg,
+            for_each_expr,
+            count_expr,
+        )?;
     }
 
     for blk in body.blocks().filter(|b| b.identifier() == "materialized") {
@@ -762,12 +871,14 @@ fn load_file(
             .as_str()
             .to_string();
         let for_each_expr = find_attr(blk.body(), "for_each");
+        let count_expr = find_attr(blk.body(), "count");
         execute_for_each::<ast::AstMaterializedView>(
             &name,
             blk.body(),
             &env,
             &mut cfg,
             for_each_expr,
+            count_expr,
         )?;
     }
 
@@ -779,7 +890,15 @@ fn load_file(
             .as_str()
             .to_string();
         let for_each_expr = find_attr(blk.body(), "for_each");
-        execute_for_each::<ast::AstPolicy>(&name, blk.body(), &env, &mut cfg, for_each_expr)?;
+        let count_expr = find_attr(blk.body(), "count");
+        execute_for_each::<ast::AstPolicy>(
+            &name,
+            blk.body(),
+            &env,
+            &mut cfg,
+            for_each_expr,
+            count_expr,
+        )?;
     }
 
     for blk in body.blocks().filter(|b| b.identifier() == "function") {
@@ -790,7 +909,15 @@ fn load_file(
             .as_str()
             .to_string();
         let for_each_expr = find_attr(blk.body(), "for_each");
-        execute_for_each::<ast::AstFunction>(&name, blk.body(), &env, &mut cfg, for_each_expr)?;
+        let count_expr = find_attr(blk.body(), "count");
+        execute_for_each::<ast::AstFunction>(
+            &name,
+            blk.body(),
+            &env,
+            &mut cfg,
+            for_each_expr,
+            count_expr,
+        )?;
     }
 
     for blk in body.blocks().filter(|b| b.identifier() == "trigger") {
@@ -801,7 +928,15 @@ fn load_file(
             .as_str()
             .to_string();
         let for_each_expr = find_attr(blk.body(), "for_each");
-        execute_for_each::<ast::AstTrigger>(&name, blk.body(), &env, &mut cfg, for_each_expr)?;
+        let count_expr = find_attr(blk.body(), "count");
+        execute_for_each::<ast::AstTrigger>(
+            &name,
+            blk.body(),
+            &env,
+            &mut cfg,
+            for_each_expr,
+            count_expr,
+        )?;
     }
 
     for blk in body.blocks().filter(|b| b.identifier() == "extension") {
@@ -812,7 +947,15 @@ fn load_file(
             .as_str()
             .to_string();
         let for_each_expr = find_attr(blk.body(), "for_each");
-        execute_for_each::<ast::AstExtension>(&name, blk.body(), &env, &mut cfg, for_each_expr)?;
+        let count_expr = find_attr(blk.body(), "count");
+        execute_for_each::<ast::AstExtension>(
+            &name,
+            blk.body(),
+            &env,
+            &mut cfg,
+            for_each_expr,
+            count_expr,
+        )?;
     }
 
     for blk in body.blocks().filter(|b| b.identifier() == "enum") {
@@ -823,7 +966,15 @@ fn load_file(
             .as_str()
             .to_string();
         let for_each_expr = find_attr(blk.body(), "for_each");
-        execute_for_each::<ast::AstEnum>(&name, blk.body(), &env, &mut cfg, for_each_expr)?;
+        let count_expr = find_attr(blk.body(), "count");
+        execute_for_each::<ast::AstEnum>(
+            &name,
+            blk.body(),
+            &env,
+            &mut cfg,
+            for_each_expr,
+            count_expr,
+        )?;
     }
 
     for blk in body.blocks().filter(|b| b.identifier() == "role") {
@@ -834,7 +985,15 @@ fn load_file(
             .as_str()
             .to_string();
         let for_each_expr = find_attr(blk.body(), "for_each");
-        execute_for_each::<ast::AstRole>(&name, blk.body(), &env, &mut cfg, for_each_expr)?;
+        let count_expr = find_attr(blk.body(), "count");
+        execute_for_each::<ast::AstRole>(
+            &name,
+            blk.body(),
+            &env,
+            &mut cfg,
+            for_each_expr,
+            count_expr,
+        )?;
     }
 
     for blk in body.blocks().filter(|b| b.identifier() == "grant") {
@@ -845,7 +1004,15 @@ fn load_file(
             .as_str()
             .to_string();
         let for_each_expr = find_attr(blk.body(), "for_each");
-        execute_for_each::<ast::AstGrant>(&name, blk.body(), &env, &mut cfg, for_each_expr)?;
+        let count_expr = find_attr(blk.body(), "count");
+        execute_for_each::<ast::AstGrant>(
+            &name,
+            blk.body(),
+            &env,
+            &mut cfg,
+            for_each_expr,
+            count_expr,
+        )?;
     }
 
     for blk in body.blocks().filter(|b| b.identifier() == "test") {

--- a/src/frontend/env.rs
+++ b/src/frontend/env.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 /// - `local.<name>` or `locals.<name>` for values in [`Self::locals`]
 /// - `module.<name>.<output>` for outputs produced by modules
 /// - `each.key`/`each.value` inside `for_each` blocks
+/// - `count.index` inside blocks using the `count` attribute
 ///
 /// # Example
 /// ```
@@ -19,6 +20,7 @@ use std::collections::HashMap;
 ///     locals: HashMap::from([( "name".into(), Value::from("bob"))]),
 ///     modules: HashMap::new(),
 ///     each: None,
+///     count: None,
 /// };
 /// // `local.name` resolves to "bob" while `var.name` resolves to "world".
 /// ```
@@ -32,4 +34,6 @@ pub struct EnvVars {
     pub modules: HashMap<String, HashMap<String, hcl::Value>>,
     /// Key/value for the current iteration of a `for_each` block, enabling `each.key` and `each.value`.
     pub each: Option<(hcl::Value, hcl::Value)>, // (key, value)
+    /// Index for `count`-based iterations, enabling `count.index`.
+    pub count: Option<usize>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -317,6 +317,35 @@ mod tests {
     }
 
     #[test]
+    fn count_creates_multiple_triggers() {
+        let mut files = HashMap::new();
+        files.insert(
+            p("/root/main.hcl"),
+            r#"
+            function "f" {
+              schema = "public"
+              language = "plpgsql"
+              returns  = "trigger"
+              body = "BEGIN RETURN NEW; END;"
+            }
+
+            trigger "t" {
+              count = 2
+              schema = "public"
+              table = "users"
+              function = "f"
+              events = ["INSERT"]
+              name = "t_${count.index}"
+            }
+            "#
+            .to_string(),
+        );
+        let loader = MapLoader { files };
+        let cfg = load_config(&p("/root/main.hcl"), &loader, EnvVars::default()).unwrap();
+        assert_eq!(cfg.triggers.len(), 2);
+    }
+
+    #[test]
     fn dynamic_block_expands_columns() {
         let mut files = HashMap::new();
         files.insert(

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,6 +147,7 @@ fn main() -> Result<()> {
                     locals: HashMap::new(),
                     modules: HashMap::new(),
                     each: None,
+                    count: None,
                 };
                 let config = load_config(&cli.input, &fs_loader, env.clone())
                     .with_context(|| format!("loading root HCL {}", cli.input.display()))?;
@@ -190,6 +191,7 @@ fn main() -> Result<()> {
                     locals: HashMap::new(),
                     modules: HashMap::new(),
                     each: None,
+                    count: None,
                 };
                 let config = load_config(&cli.input, &fs_loader, env.clone())
                     .with_context(|| format!("loading root HCL {}", cli.input.display()))?;
@@ -241,6 +243,7 @@ fn main() -> Result<()> {
                         locals: HashMap::new(),
                         modules: HashMap::new(),
                         each: None,
+                        count: None,
                     };
                     let cfg = load_config(&PathBuf::from(input_path), &fs_loader, env.clone())
                         .with_context(|| format!("loading root HCL from {}", input_path))?;
@@ -275,6 +278,7 @@ fn main() -> Result<()> {
                         locals: HashMap::new(),
                         modules: HashMap::new(),
                         each: None,
+                        count: None,
                     };
                     let cfg = load_config(&cli.input, &fs_loader, env.clone())
                         .with_context(|| format!("loading root HCL {}", cli.input.display()))?;

--- a/tests/pglite_backend.rs
+++ b/tests/pglite_backend.rs
@@ -48,6 +48,7 @@ fn pglite_backend_runs_test() -> Result<()> {
             locals: HashMap::new(),
             modules: HashMap::new(),
             each: None,
+            count: None,
         },
     )?;
 


### PR DESCRIPTION
## Summary
- handle `count` on blocks and expose `count.index`
- allow iterating resources and modules by count
- document and exemplify `count`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b72738b98c8331a616c4a80b9bcf2e