### PR TITLE
Handle count on sequence blocks

### DIFF
--- a/src/frontend/core.rs
+++ b/src/frontend/core.rs
@@ -835,7 +835,15 @@ fn load_file(
             .as_str()
             .to_string();
         let for_each_expr = find_attr(blk.body(), "for_each");
-        execute_for_each::<ast::AstSequence>(&name, blk.body(), &env, &mut cfg, for_each_expr)?;
+        let count_expr = find_attr(blk.body(), "count");
+        execute_for_each::<ast::AstSequence>(
+            &name,
+            blk.body(),
+            &env,
+            &mut cfg,
+            for_each_expr,
+            count_expr,
+        )?;
     }
 
     for blk in body.blocks().filter(|b| b.identifier() == "table") {


### PR DESCRIPTION
## Summary
- handle `count` attribute for `sequence` blocks

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b72bdbbf688331803a87d5dfba8e22