### PR TITLE
Add domain and composite type support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Prisma ORM support custom migrations, so you can use this tool to generate an SQ
    - `locals`
    - `schema`
    - `enum`
+   - `domain`
+   - `type`
    - `sequence`
    - `table`
    - `view`
@@ -185,6 +187,23 @@ enum "<name>" {
   name   = "<new_name>"     # optional, overrides the block name
   schema = "public"    # optional, default "public"
   values = ["a", "b"]  # required
+}
+
+domain "<name>" {
+  name      = "<new_name>"   # optional, overrides the block name
+  schema    = "public"       # optional, default "public"
+  type      = "text"         # required base type
+  not_null  = false           # optional
+  default   = null            # optional
+  constraint = null           # optional constraint name
+  check     = "VALUE <> ''"  # optional CHECK expression
+}
+
+type "<name>" {
+  name   = "<new_name>"   # optional, overrides the block name
+  schema = "public"       # optional, default "public"
+  field "a" { type = "int" }
+  field "b" { type = "text" }
 }
 
 sequence "<name>" {

--- a/examples/domain.hcl
+++ b/examples/domain.hcl
@@ -1,0 +1,8 @@
+domain "email" {
+  type = "text"
+  check = "VALUE ~* '^[^@]+@[^@]+$'"
+}
+
+test "email_domain" {
+  assert = "SELECT 'user@example.com'::email IS NOT NULL"
+}

--- a/examples/type.hcl
+++ b/examples/type.hcl
@@ -1,0 +1,8 @@
+type "address" {
+  field "street" { type = "text" }
+  field "zip" { type = "int" }
+}
+
+test "address_type" {
+  assert = "SELECT ROW('road',12345)::address IS NOT NULL"
+}

--- a/src/backends/postgres.rs
+++ b/src/backends/postgres.rs
@@ -39,6 +39,14 @@ fn to_sql(cfg: &Config) -> Result<String> {
         out.push_str(&format!("{}\n\n", pg::Enum::from(e)));
     }
 
+    for d in &cfg.domains {
+        out.push_str(&format!("{}\n\n", pg::Domain::from(d)));
+    }
+
+    for t in &cfg.types {
+        out.push_str(&format!("{}\n\n", pg::CompositeType::from(t)));
+    }
+
     for t in &cfg.tables {
         out.push_str(&format!("{}\n\n", pg::Table::from(t)));
         for idx in &t.indexes {

--- a/src/config.rs
+++ b/src/config.rs
@@ -75,6 +75,8 @@ pub struct Config {
 pub enum ResourceKind {
     Schemas,
     Enums,
+    Domains,
+    Types,
     Tables,
     Views,
     Materialized,
@@ -93,6 +95,8 @@ impl fmt::Display for ResourceKind {
         let s = match self {
             ResourceKind::Schemas => "schemas",
             ResourceKind::Enums => "enums",
+            ResourceKind::Domains => "domains",
+            ResourceKind::Types => "types",
             ResourceKind::Tables => "tables",
             ResourceKind::Views => "views",
             ResourceKind::Materialized => "materialized",
@@ -116,6 +120,8 @@ impl std::str::FromStr for ResourceKind {
         match s.to_lowercase().as_str() {
             "schemas" => Ok(ResourceKind::Schemas),
             "enums" => Ok(ResourceKind::Enums),
+            "domains" => Ok(ResourceKind::Domains),
+            "types" => Ok(ResourceKind::Types),
             "tables" => Ok(ResourceKind::Tables),
             "views" => Ok(ResourceKind::Views),
             "materialized" => Ok(ResourceKind::Materialized),
@@ -140,6 +146,8 @@ impl TargetConfig {
             vec![
                 ResourceKind::Schemas,
                 ResourceKind::Enums,
+                ResourceKind::Domains,
+                ResourceKind::Types,
                 ResourceKind::Tables,
                 ResourceKind::Views,
                 ResourceKind::Materialized,
@@ -215,7 +223,7 @@ mod tests {
         let include_set = target.get_include_set();
         assert!(include_set.contains(&ResourceKind::Tables));
         assert!(include_set.contains(&ResourceKind::Enums));
-        assert_eq!(include_set.len(), 13); // All resource types
+        assert_eq!(include_set.len(), 15); // All resource types
     }
 
     #[test]

--- a/src/frontend/ast/mod.rs
+++ b/src/frontend/ast/mod.rs
@@ -8,6 +8,8 @@ pub struct Config {
     pub sequences: Vec<AstSequence>,
     pub schemas: Vec<AstSchema>,
     pub enums: Vec<AstEnum>,
+    pub domains: Vec<AstDomain>,
+    pub types: Vec<AstCompositeType>,
     pub tables: Vec<AstTable>,
     pub views: Vec<AstView>,
     pub materialized: Vec<AstMaterializedView>,
@@ -83,6 +85,32 @@ pub struct AstEnum {
     pub alt_name: Option<String>,
     pub schema: Option<String>,
     pub values: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AstDomain {
+    pub name: String,
+    pub alt_name: Option<String>,
+    pub schema: Option<String>,
+    pub r#type: String,
+    pub not_null: bool,
+    pub default: Option<String>,
+    pub constraint: Option<String>,
+    pub check: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AstCompositeType {
+    pub name: String,
+    pub alt_name: Option<String>,
+    pub schema: Option<String>,
+    pub fields: Vec<AstCompositeTypeField>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AstCompositeTypeField {
+    pub name: String,
+    pub r#type: String,
 }
 
 #[derive(Debug, Clone)]

--- a/src/frontend/core.rs
+++ b/src/frontend/core.rs
@@ -793,6 +793,8 @@ fn load_file(
             env.modules.insert(label.as_str().to_string(), map);
             cfg.schemas.extend(sub.schemas);
             cfg.enums.extend(sub.enums);
+            cfg.domains.extend(sub.domains);
+            cfg.types.extend(sub.types);
             cfg.functions.extend(sub.functions);
             cfg.triggers.extend(sub.triggers);
             cfg.extensions.extend(sub.extensions);
@@ -989,6 +991,44 @@ fn load_file(
         let for_each_expr = find_attr(blk.body(), "for_each");
         let count_expr = find_attr(blk.body(), "count");
         execute_for_each::<ast::AstEnum>(
+            &name,
+            blk.body(),
+            &env,
+            &mut cfg,
+            for_each_expr,
+            count_expr,
+        )?;
+    }
+
+    for blk in body.blocks().filter(|b| b.identifier() == "domain") {
+        let name = blk
+            .labels()
+            .get(0)
+            .ok_or_else(|| anyhow::anyhow!("domain block missing name label"))?
+            .as_str()
+            .to_string();
+        let for_each_expr = find_attr(blk.body(), "for_each");
+        let count_expr = find_attr(blk.body(), "count");
+        execute_for_each::<ast::AstDomain>(
+            &name,
+            blk.body(),
+            &env,
+            &mut cfg,
+            for_each_expr,
+            count_expr,
+        )?;
+    }
+
+    for blk in body.blocks().filter(|b| b.identifier() == "type") {
+        let name = blk
+            .labels()
+            .get(0)
+            .ok_or_else(|| anyhow::anyhow!("type block missing name label"))?
+            .as_str()
+            .to_string();
+        let for_each_expr = find_attr(blk.body(), "for_each");
+        let count_expr = find_attr(blk.body(), "count");
+        execute_for_each::<ast::AstCompositeType>(
             &name,
             blk.body(),
             &env,

--- a/src/frontend/lower.rs
+++ b/src/frontend/lower.rs
@@ -9,6 +9,8 @@ pub fn lower_config(ast: ast::Config) -> ir::Config {
         sequences: ast.sequences.into_iter().map(Into::into).collect(),
         schemas: ast.schemas.into_iter().map(Into::into).collect(),
         enums: ast.enums.into_iter().map(Into::into).collect(),
+        domains: ast.domains.into_iter().map(Into::into).collect(),
+        types: ast.types.into_iter().map(Into::into).collect(),
         tables: ast.tables.into_iter().map(Into::into).collect(),
         views: ast.views.into_iter().map(Into::into).collect(),
         materialized: ast.materialized.into_iter().map(Into::into).collect(),
@@ -101,6 +103,41 @@ impl From<ast::AstEnum> for ir::EnumSpec {
             alt_name: e.alt_name,
             schema: e.schema,
             values: e.values,
+        }
+    }
+}
+
+impl From<ast::AstDomain> for ir::DomainSpec {
+    fn from(d: ast::AstDomain) -> Self {
+        Self {
+            name: d.name,
+            alt_name: d.alt_name,
+            schema: d.schema,
+            r#type: d.r#type,
+            not_null: d.not_null,
+            default: d.default,
+            constraint: d.constraint,
+            check: d.check,
+        }
+    }
+}
+
+impl From<ast::AstCompositeType> for ir::CompositeTypeSpec {
+    fn from(t: ast::AstCompositeType) -> Self {
+        Self {
+            name: t.name,
+            alt_name: t.alt_name,
+            schema: t.schema,
+            fields: t.fields.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<ast::AstCompositeTypeField> for ir::CompositeTypeFieldSpec {
+    fn from(f: ast::AstCompositeTypeField) -> Self {
+        Self {
+            name: f.name,
+            r#type: f.r#type,
         }
     }
 }

--- a/src/ir/config.rs
+++ b/src/ir/config.rs
@@ -9,6 +9,8 @@ pub struct Config {
     pub sequences: Vec<SequenceSpec>,
     pub schemas: Vec<SchemaSpec>,
     pub enums: Vec<EnumSpec>,
+    pub domains: Vec<DomainSpec>,
+    pub types: Vec<CompositeTypeSpec>,
     pub tables: Vec<TableSpec>,
     pub views: Vec<ViewSpec>,
     pub materialized: Vec<MaterializedViewSpec>,
@@ -84,6 +86,32 @@ pub struct EnumSpec {
     pub alt_name: Option<String>,
     pub schema: Option<String>,
     pub values: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DomainSpec {
+    pub name: String,
+    pub alt_name: Option<String>,
+    pub schema: Option<String>,
+    pub r#type: String,
+    pub not_null: bool,
+    pub default: Option<String>,
+    pub constraint: Option<String>,
+    pub check: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CompositeTypeSpec {
+    pub name: String,
+    pub alt_name: Option<String>,
+    pub schema: Option<String>,
+    pub fields: Vec<CompositeTypeFieldSpec>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CompositeTypeFieldSpec {
+    pub name: String,
+    pub r#type: String,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -1,7 +1,8 @@
 pub mod config;
 
 pub use config::{
-    BackReferenceSpec, ColumnSpec, Config, EnumSpec, ExtensionSpec, ForeignKeySpec, FunctionSpec,
-    GrantSpec, IndexSpec, MaterializedViewSpec, OutputSpec, PolicySpec, PrimaryKeySpec, RoleSpec,
-    SchemaSpec, SequenceSpec, TableSpec, TestSpec, TriggerSpec, ViewSpec,
+    BackReferenceSpec, ColumnSpec, CompositeTypeFieldSpec, CompositeTypeSpec, Config, DomainSpec,
+    EnumSpec, ExtensionSpec, ForeignKeySpec, FunctionSpec, GrantSpec, IndexSpec,
+    MaterializedViewSpec, OutputSpec, PolicySpec, PrimaryKeySpec, RoleSpec, SchemaSpec,
+    SequenceSpec, TableSpec, TestSpec, TriggerSpec, ViewSpec,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,8 +14,9 @@ use std::path::Path;
 // Public re-exports
 use crate::frontend::env::EnvVars;
 pub use ir::{
-    Config, EnumSpec, ExtensionSpec, FunctionSpec, GrantSpec, MaterializedViewSpec, OutputSpec,
-    PolicySpec, RoleSpec, SchemaSpec, SequenceSpec, TableSpec, TriggerSpec, ViewSpec,
+    CompositeTypeSpec, Config, DomainSpec, EnumSpec, ExtensionSpec, FunctionSpec, GrantSpec,
+    MaterializedViewSpec, OutputSpec, PolicySpec, RoleSpec, SchemaSpec, SequenceSpec, TableSpec,
+    TriggerSpec, ViewSpec,
 };
 
 // Loader abstraction: lets callers control how files are read.
@@ -54,6 +55,8 @@ where
         sequences: maybe!(Sequences, sequences),
         schemas: maybe!(Schemas, schemas),
         enums: maybe!(Enums, enums),
+        domains: maybe!(Domains, domains),
+        types: maybe!(Types, types),
         tables: maybe!(Tables, tables),
         views: maybe!(Views, views),
         materialized: maybe!(Materialized, materialized),

--- a/src/main.rs
+++ b/src/main.rs
@@ -594,6 +594,8 @@ fn cli_filter_sets(
         [
             R::Schemas,
             R::Enums,
+            R::Domains,
+            R::Types,
             R::Tables,
             R::Views,
             R::Materialized,


### PR DESCRIPTION
## Summary
- support `domain` and `type` blocks with AST structures and parser hooks
- render `CREATE DOMAIN` and `CREATE TYPE` in Postgres backend
- document new blocks and provide sample HCL

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b73541c4908331946e79a329c9f04e