### PR TITLE
Add lint framework and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,30 @@ test_backend = "pglite"
 - Validate: `./target/release/dbschema --input examples/main.hcl validate`
 - Create migration (Postgres SQL): `./target/release/dbschema --input examples/main.hcl create-migration --out-dir migrations --name triggers`
 - Create Prisma models/enums only (no generator/datasource): `./target/release/dbschema --backend prisma --input examples/main.hcl create-migration --out-dir prisma --name schema`
+- Lint schema: `./target/release/dbschema --input examples/main.hcl lint`
 - Variables: `--var schema=public` or `--var-file .env.hcl`
 - Using config file: `dbschema --config` or `dbschema --config --target <target_name>`
+
+
+## Linting
+
+`dbschema lint` runs built-in checks against your schema. The default checks are:
+
+- `naming-convention`: table and column names must be `snake_case`.
+- `missing-index`: tables should define at least one index or primary key.
+
+Suppress a rule for a specific table or column with `lint_ignore`:
+
+```hcl
+table "users" {
+  lint_ignore = ["missing-index"]
+
+  column "ID" {
+    type = "int"
+    lint_ignore = ["naming-convention"]
+  }
+}
+```
 
 ## Logging
 

--- a/src/frontend/ast/mod.rs
+++ b/src/frontend/ast/mod.rs
@@ -144,6 +144,7 @@ pub struct AstTable {
     pub indexes: Vec<AstIndex>,
     pub foreign_keys: Vec<AstForeignKey>,
     pub back_references: Vec<AstBackReference>,
+    pub lint_ignore: Vec<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -159,6 +160,7 @@ pub struct AstColumn {
     pub nullable: bool,
     pub default: Option<String>,
     pub db_type: Option<String>,
+    pub lint_ignore: Vec<String>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/frontend/lower.rs
+++ b/src/frontend/lower.rs
@@ -180,6 +180,7 @@ impl From<ast::AstTable> for ir::TableSpec {
             indexes: t.indexes.into_iter().map(Into::into).collect(),
             foreign_keys: t.foreign_keys.into_iter().map(Into::into).collect(),
             back_references: t.back_references.into_iter().map(Into::into).collect(),
+            lint_ignore: t.lint_ignore,
         }
     }
 }
@@ -192,6 +193,7 @@ impl From<ast::AstColumn> for ir::ColumnSpec {
             nullable: c.nullable,
             default: c.default,
             db_type: c.db_type,
+            lint_ignore: c.lint_ignore,
         }
     }
 }

--- a/src/frontend/resource_impls.rs
+++ b/src/frontend/resource_impls.rs
@@ -97,12 +97,17 @@ impl ForEachSupport for AstTable {
             let nullable = get_attr_bool(cb, "nullable", env)?.unwrap_or(true);
             let default = get_attr_string(cb, "default", env)?;
             let db_type = get_attr_string(cb, "db_type", env)?;
+            let lint_ignore = match find_attr(cb, "lint_ignore") {
+                Some(attr) => expr_to_string_vec(attr.expr(), env)?,
+                None => Vec::new(),
+            };
             columns.push(AstColumn {
                 name: cname,
                 r#type: ctype,
                 nullable,
                 default,
                 db_type,
+                lint_ignore,
             });
         }
 
@@ -190,6 +195,11 @@ impl ForEachSupport for AstTable {
             });
         }
 
+        let lint_ignore = match find_attr(body, "lint_ignore") {
+            Some(attr) => expr_to_string_vec(attr.expr(), env)?,
+            None => Vec::new(),
+        };
+
         Ok(AstTable {
             name: name.to_string(),
             table_name,
@@ -200,6 +210,7 @@ impl ForEachSupport for AstTable {
             indexes,
             foreign_keys: fks,
             back_references: Vec::new(),
+            lint_ignore,
         })
     }
 

--- a/src/ir/config.rs
+++ b/src/ir/config.rs
@@ -145,6 +145,7 @@ pub struct TableSpec {
     pub indexes: Vec<IndexSpec>,
     pub foreign_keys: Vec<ForeignKeySpec>,
     pub back_references: Vec<BackReferenceSpec>,
+    pub lint_ignore: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -160,6 +161,7 @@ pub struct ColumnSpec {
     pub nullable: bool,
     pub default: Option<String>,
     pub db_type: Option<String>, // NEW: Database-specific type like "CHAR(32)", "VARCHAR(255)"
+    pub lint_ignore: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod passes;
 pub mod postgres;
 pub mod prisma;
 pub mod test_runner;
+pub mod lint;
 
 use anyhow::Result;
 // Keep types public via re-exports
@@ -603,6 +604,7 @@ mod tests {
                 indexes: vec![],
                 foreign_keys: vec![],
                 back_references: vec![],
+                lint_ignore: vec![],
             }],
             ..Default::default()
         };
@@ -639,6 +641,7 @@ mod tests {
                 indexes: vec![],
                 foreign_keys: vec![],
                 back_references: vec![],
+                lint_ignore: vec![],
             }],
             ..Default::default()
         };

--- a/src/lint/mod.rs
+++ b/src/lint/mod.rs
@@ -1,0 +1,113 @@
+use crate::ir::Config;
+
+#[derive(Debug)]
+pub struct LintMessage {
+    pub check: &'static str,
+    pub message: String,
+}
+
+pub trait LintCheck {
+    fn name(&self) -> &'static str;
+    fn run(&self, cfg: &Config) -> Vec<LintMessage>;
+}
+
+pub fn run(cfg: &Config) -> Vec<LintMessage> {
+    let checks: Vec<Box<dyn LintCheck>> = vec![
+        Box::new(NamingConvention),
+        Box::new(MissingIndex),
+    ];
+    run_with_checks(cfg, checks)
+}
+
+pub fn run_with_checks(cfg: &Config, checks: Vec<Box<dyn LintCheck>>) -> Vec<LintMessage> {
+    let mut messages = Vec::new();
+    for check in checks {
+        messages.extend(check.run(cfg));
+    }
+    messages
+}
+
+struct NamingConvention;
+
+impl NamingConvention {
+    fn is_snake_case(s: &str) -> bool {
+        let mut chars = s.chars();
+        match chars.next() {
+            Some(c) if c.is_ascii_lowercase() || c == '_' => (),
+            _ => return false,
+        }
+        chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+    }
+
+    fn ignored(ignores: &[String], rule: &str) -> bool {
+        ignores.iter().any(|i| i == rule)
+    }
+}
+
+impl LintCheck for NamingConvention {
+    fn name(&self) -> &'static str {
+        "naming-convention"
+    }
+
+    fn run(&self, cfg: &Config) -> Vec<LintMessage> {
+        let mut msgs = Vec::new();
+        for table in &cfg.tables {
+            if Self::ignored(&table.lint_ignore, self.name()) {
+                continue;
+            }
+            if !Self::is_snake_case(&table.name) {
+                msgs.push(LintMessage {
+                    check: self.name(),
+                    message: format!("table '{}' should be snake_case", table.name),
+                });
+            }
+            for col in &table.columns {
+                if Self::ignored(&col.lint_ignore, self.name())
+                    || Self::ignored(&table.lint_ignore, self.name())
+                {
+                    continue;
+                }
+                if !Self::is_snake_case(&col.name) {
+                    msgs.push(LintMessage {
+                        check: self.name(),
+                        message: format!(
+                            "column '{}.{}' should be snake_case",
+                            table.name, col.name
+                        ),
+                    });
+                }
+            }
+        }
+        msgs
+    }
+}
+
+struct MissingIndex;
+
+impl MissingIndex {
+    fn ignored(ignores: &[String], rule: &str) -> bool {
+        ignores.iter().any(|i| i == rule)
+    }
+}
+
+impl LintCheck for MissingIndex {
+    fn name(&self) -> &'static str {
+        "missing-index"
+    }
+
+    fn run(&self, cfg: &Config) -> Vec<LintMessage> {
+        let mut msgs = Vec::new();
+        for table in &cfg.tables {
+            if Self::ignored(&table.lint_ignore, self.name()) {
+                continue;
+            }
+            if table.indexes.is_empty() && table.primary_key.is_none() {
+                msgs.push(LintMessage {
+                    check: self.name(),
+                    message: format!("table '{}' has no indexes", table.name),
+                });
+            }
+        }
+        msgs
+    }
+}


### PR DESCRIPTION
## Summary
- introduce lint module with naming and index checks
- add `dbschema lint` command to run pluggable lints
- document lint rules and suppression via `lint_ignore`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b73550f1e083319577e9223cd14c4d