### PR TITLE
Add comprehension and conditional expression support

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ module "<name>" {
 
 ## Expression Language
 
-dbschema evaluates HCL expressions with support for strings, numbers, booleans, arrays, objects, function calls, traversals like `var.*` and `local.*`, and `${...}` string templates.
+ dbschema evaluates HCL expressions with support for strings, numbers, booleans, arrays, objects, function calls, traversals like `var.*` and `local.*`, `${...}` string templates, list comprehensions (`[for x in list : expr]`), and conditional expressions (`a ? b : c`).
 
 ## Variables, for_each, dynamic blocks, and each.value
 

--- a/examples/expression.hcl
+++ b/examples/expression.hcl
@@ -1,0 +1,18 @@
+variable "users" {
+  default = [
+    "alice",
+    "bob"
+  ]
+}
+
+output "greetings" {
+  value = [for u in var.users : "hi ${upper(u)}"]
+}
+
+variable "premium" {
+  default = false
+}
+
+output "plan" {
+  value = var.premium ? "pro" : "basic"
+}


### PR DESCRIPTION
## Summary
- support variables, conditionals, and for expressions in HCL evaluator
- document and demonstrate list comprehension and ternary expressions

## Testing
- `cargo test`
- `cargo run -- fmt examples/expression.hcl`


------
https://chatgpt.com/codex/tasks/task_e_68b739bef12883318e58ca00993827ce