### PR TITLE
Support SQL comments for schema objects

### DIFF
--- a/src/backends/postgres.rs
+++ b/src/backends/postgres.rs
@@ -21,57 +21,194 @@ fn to_sql(cfg: &Config) -> Result<String> {
 
     for r in &cfg.roles {
         out.push_str(&format!("{}\n\n", pg::Role::from(r)));
+        if let Some(comment) = &r.comment {
+            let name = r.alt_name.clone().unwrap_or_else(|| r.name.clone());
+            out.push_str(&format!(
+                "COMMENT ON ROLE {} IS {};\n\n",
+                pg::ident(&name),
+                pg::literal(comment)
+            ));
+        }
     }
 
     for s in &cfg.schemas {
         out.push_str(&format!("{}\n\n", pg::Schema::from(s)));
+        if let Some(comment) = &s.comment {
+            let name = s.alt_name.clone().unwrap_or_else(|| s.name.clone());
+            out.push_str(&format!(
+                "COMMENT ON SCHEMA {} IS {};\n\n",
+                pg::ident(&name),
+                pg::literal(comment)
+            ));
+        }
     }
 
     for e in &cfg.extensions {
         out.push_str(&format!("{}\n\n", pg::Extension::from(e)));
+        if let Some(comment) = &e.comment {
+            let name = e.alt_name.clone().unwrap_or_else(|| e.name.clone());
+            out.push_str(&format!(
+                "COMMENT ON EXTENSION {} IS {};\n\n",
+                pg::ident(&name),
+                pg::literal(comment)
+            ));
+        }
     }
 
     for s in &cfg.sequences {
         out.push_str(&format!("{}\n\n", pg::Sequence::from(s)));
+        if let Some(comment) = &s.comment {
+            let schema = s.schema.clone().unwrap_or_else(|| "public".to_string());
+            let name = s.alt_name.clone().unwrap_or_else(|| s.name.clone());
+            out.push_str(&format!(
+                "COMMENT ON SEQUENCE {}.{} IS {};\n\n",
+                pg::ident(&schema),
+                pg::ident(&name),
+                pg::literal(comment)
+            ));
+        }
     }
 
     for e in &cfg.enums {
         out.push_str(&format!("{}\n\n", pg::Enum::from(e)));
+        if let Some(comment) = &e.comment {
+            let schema = e.schema.clone().unwrap_or_else(|| "public".to_string());
+            let name = e.alt_name.clone().unwrap_or_else(|| e.name.clone());
+            out.push_str(&format!(
+                "COMMENT ON TYPE {}.{} IS {};\n\n",
+                pg::ident(&schema),
+                pg::ident(&name),
+                pg::literal(comment)
+            ));
+        }
     }
 
     for d in &cfg.domains {
         out.push_str(&format!("{}\n\n", pg::Domain::from(d)));
+        if let Some(comment) = &d.comment {
+            let schema = d.schema.clone().unwrap_or_else(|| "public".to_string());
+            let name = d.alt_name.clone().unwrap_or_else(|| d.name.clone());
+            out.push_str(&format!(
+                "COMMENT ON DOMAIN {}.{} IS {};\n\n",
+                pg::ident(&schema),
+                pg::ident(&name),
+                pg::literal(comment)
+            ));
+        }
     }
 
     for t in &cfg.types {
         out.push_str(&format!("{}\n\n", pg::CompositeType::from(t)));
+        if let Some(comment) = &t.comment {
+            let schema = t.schema.clone().unwrap_or_else(|| "public".to_string());
+            let name = t.alt_name.clone().unwrap_or_else(|| t.name.clone());
+            out.push_str(&format!(
+                "COMMENT ON TYPE {}.{} IS {};\n\n",
+                pg::ident(&schema),
+                pg::ident(&name),
+                pg::literal(comment)
+            ));
+        }
     }
 
     for t in &cfg.tables {
         out.push_str(&format!("{}\n\n", pg::Table::from(t)));
+        let schema = t.schema.clone().unwrap_or_else(|| "public".to_string());
+        let table_name = t.table_name.clone().unwrap_or_else(|| t.name.clone());
         for idx in &t.indexes {
             out.push_str(&format!("{}\n\n", pg::Index::from_specs(t, idx)));
+        }
+        if let Some(comment) = &t.comment {
+            out.push_str(&format!(
+                "COMMENT ON TABLE {}.{} IS {};\n\n",
+                pg::ident(&schema),
+                pg::ident(&table_name),
+                pg::literal(comment)
+            ));
+        }
+        for c in &t.columns {
+            if let Some(comment) = &c.comment {
+                out.push_str(&format!(
+                    "COMMENT ON COLUMN {}.{}.{} IS {};\n\n",
+                    pg::ident(&schema),
+                    pg::ident(&table_name),
+                    pg::ident(&c.name),
+                    pg::literal(comment)
+                ));
+            }
         }
     }
 
     for p in &cfg.policies {
         out.push_str(&format!("{}\n\n", pg::Policy::from(p)));
+        if let Some(comment) = &p.comment {
+            let schema = p.schema.clone().unwrap_or_else(|| "public".to_string());
+            let name = p.alt_name.clone().unwrap_or_else(|| p.name.clone());
+            out.push_str(&format!(
+                "COMMENT ON POLICY {} ON {}.{} IS {};\n\n",
+                pg::ident(&name),
+                pg::ident(&schema),
+                pg::ident(&p.table),
+                pg::literal(comment)
+            ));
+        }
     }
 
     for f in &cfg.functions {
         out.push_str(&format!("{}\n\n", pg::Function::from(f)));
+        if let Some(comment) = &f.comment {
+            let schema = f.schema.clone().unwrap_or_else(|| "public".to_string());
+            let name = f.alt_name.clone().unwrap_or_else(|| f.name.clone());
+            out.push_str(&format!(
+                "COMMENT ON FUNCTION {}.{}() IS {};\n\n",
+                pg::ident(&schema),
+                pg::ident(&name),
+                pg::literal(comment)
+            ));
+        }
     }
 
     for v in &cfg.views {
         out.push_str(&format!("{}\n\n", pg::View::from(v)));
+        if let Some(comment) = &v.comment {
+            let schema = v.schema.clone().unwrap_or_else(|| "public".to_string());
+            let name = v.alt_name.clone().unwrap_or_else(|| v.name.clone());
+            out.push_str(&format!(
+                "COMMENT ON VIEW {}.{} IS {};\n\n",
+                pg::ident(&schema),
+                pg::ident(&name),
+                pg::literal(comment)
+            ));
+        }
     }
 
     for mv in &cfg.materialized {
         out.push_str(&format!("{}\n\n", pg::MaterializedView::from(mv)));
+        if let Some(comment) = &mv.comment {
+            let schema = mv.schema.clone().unwrap_or_else(|| "public".to_string());
+            let name = mv.alt_name.clone().unwrap_or_else(|| mv.name.clone());
+            out.push_str(&format!(
+                "COMMENT ON MATERIALIZED VIEW {}.{} IS {};\n\n",
+                pg::ident(&schema),
+                pg::ident(&name),
+                pg::literal(comment)
+            ));
+        }
     }
 
     for t in &cfg.triggers {
         out.push_str(&format!("{}\n\n", pg::Trigger::from(t)));
+        if let Some(comment) = &t.comment {
+            let schema = t.schema.clone().unwrap_or_else(|| "public".to_string());
+            let name = t.alt_name.clone().unwrap_or_else(|| t.name.clone());
+            out.push_str(&format!(
+                "COMMENT ON TRIGGER {} ON {}.{} IS {};\n\n",
+                pg::ident(&name),
+                pg::ident(&schema),
+                pg::ident(&t.table),
+                pg::literal(comment)
+            ));
+        }
     }
 
     for g in &cfg.grants {

--- a/src/frontend/ast/mod.rs
+++ b/src/frontend/ast/mod.rs
@@ -30,6 +30,7 @@ pub struct AstFunction {
     pub replace: bool,
     pub security_definer: bool,
     pub body: String,
+    pub comment: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -44,6 +45,7 @@ pub struct AstTrigger {
     pub function: String,
     pub function_schema: Option<String>,
     pub when: Option<String>,
+    pub comment: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -53,6 +55,7 @@ pub struct AstExtension {
     pub if_not_exists: bool,
     pub schema: Option<String>,
     pub version: Option<String>,
+    pub comment: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -69,6 +72,7 @@ pub struct AstSequence {
     pub cache: Option<i64>,
     pub cycle: bool,
     pub owned_by: Option<String>,
+    pub comment: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -77,6 +81,7 @@ pub struct AstSchema {
     pub alt_name: Option<String>,
     pub if_not_exists: bool,
     pub authorization: Option<String>,
+    pub comment: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -85,6 +90,7 @@ pub struct AstEnum {
     pub alt_name: Option<String>,
     pub schema: Option<String>,
     pub values: Vec<String>,
+    pub comment: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -97,6 +103,7 @@ pub struct AstDomain {
     pub default: Option<String>,
     pub constraint: Option<String>,
     pub check: Option<String>,
+    pub comment: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -105,6 +112,7 @@ pub struct AstCompositeType {
     pub alt_name: Option<String>,
     pub schema: Option<String>,
     pub fields: Vec<AstCompositeTypeField>,
+    pub comment: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -120,6 +128,7 @@ pub struct AstView {
     pub schema: Option<String>,
     pub replace: bool,
     pub sql: String,
+    pub comment: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -129,6 +138,7 @@ pub struct AstMaterializedView {
     pub schema: Option<String>,
     pub with_data: bool,
     pub sql: String,
+    pub comment: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -142,6 +152,7 @@ pub struct AstPolicy {
     pub roles: Vec<String>,
     pub using: Option<String>,
     pub check: Option<String>,
+    pub comment: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -149,6 +160,7 @@ pub struct AstRole {
     pub name: String,
     pub alt_name: Option<String>,
     pub login: bool,
+    pub comment: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -173,6 +185,7 @@ pub struct AstTable {
     pub foreign_keys: Vec<AstForeignKey>,
     pub back_references: Vec<AstBackReference>,
     pub lint_ignore: Vec<String>,
+    pub comment: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -189,6 +202,7 @@ pub struct AstColumn {
     pub default: Option<String>,
     pub db_type: Option<String>,
     pub lint_ignore: Vec<String>,
+    pub comment: Option<String>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/frontend/lower.rs
+++ b/src/frontend/lower.rs
@@ -33,6 +33,7 @@ impl From<ast::AstFunction> for ir::FunctionSpec {
             replace: f.replace,
             security_definer: f.security_definer,
             body: f.body,
+            comment: f.comment,
         }
     }
 }
@@ -50,6 +51,7 @@ impl From<ast::AstTrigger> for ir::TriggerSpec {
             function: t.function,
             function_schema: t.function_schema,
             when: t.when,
+            comment: t.comment,
         }
     }
 }
@@ -62,6 +64,7 @@ impl From<ast::AstExtension> for ir::ExtensionSpec {
             if_not_exists: e.if_not_exists,
             schema: e.schema,
             version: e.version,
+            comment: e.comment,
         }
     }
 }
@@ -81,6 +84,7 @@ impl From<ast::AstSequence> for ir::SequenceSpec {
             cache: s.cache,
             cycle: s.cycle,
             owned_by: s.owned_by,
+            comment: s.comment,
         }
     }
 }
@@ -92,6 +96,7 @@ impl From<ast::AstSchema> for ir::SchemaSpec {
             alt_name: s.alt_name,
             if_not_exists: s.if_not_exists,
             authorization: s.authorization,
+            comment: s.comment,
         }
     }
 }
@@ -103,6 +108,7 @@ impl From<ast::AstEnum> for ir::EnumSpec {
             alt_name: e.alt_name,
             schema: e.schema,
             values: e.values,
+            comment: e.comment,
         }
     }
 }
@@ -118,6 +124,7 @@ impl From<ast::AstDomain> for ir::DomainSpec {
             default: d.default,
             constraint: d.constraint,
             check: d.check,
+            comment: d.comment,
         }
     }
 }
@@ -129,6 +136,7 @@ impl From<ast::AstCompositeType> for ir::CompositeTypeSpec {
             alt_name: t.alt_name,
             schema: t.schema,
             fields: t.fields.into_iter().map(Into::into).collect(),
+            comment: t.comment,
         }
     }
 }
@@ -150,6 +158,7 @@ impl From<ast::AstView> for ir::ViewSpec {
             schema: v.schema,
             replace: v.replace,
             sql: v.sql,
+            comment: v.comment,
         }
     }
 }
@@ -162,6 +171,7 @@ impl From<ast::AstMaterializedView> for ir::MaterializedViewSpec {
             schema: m.schema,
             with_data: m.with_data,
             sql: m.sql,
+            comment: m.comment,
         }
     }
 }
@@ -178,6 +188,7 @@ impl From<ast::AstPolicy> for ir::PolicySpec {
             roles: p.roles,
             using: p.using,
             check: p.check,
+            comment: p.comment,
         }
     }
 }
@@ -188,6 +199,7 @@ impl From<ast::AstRole> for ir::RoleSpec {
             name: r.name,
             alt_name: r.alt_name,
             login: r.login,
+            comment: r.comment,
         }
     }
 }
@@ -218,6 +230,7 @@ impl From<ast::AstTable> for ir::TableSpec {
             foreign_keys: t.foreign_keys.into_iter().map(Into::into).collect(),
             back_references: t.back_references.into_iter().map(Into::into).collect(),
             lint_ignore: t.lint_ignore,
+            comment: t.comment,
         }
     }
 }
@@ -231,6 +244,7 @@ impl From<ast::AstColumn> for ir::ColumnSpec {
             default: c.default,
             db_type: c.db_type,
             lint_ignore: c.lint_ignore,
+            comment: c.comment,
         }
     }
 }

--- a/src/frontend/resource_impls.rs
+++ b/src/frontend/resource_impls.rs
@@ -14,11 +14,13 @@ impl ForEachSupport for AstSchema {
         let alt_name = get_attr_string(body, "name", env)?;
         let if_not_exists = get_attr_bool(body, "if_not_exists", env)?.unwrap_or(true);
         let authorization = get_attr_string(body, "authorization", env)?;
+        let comment = get_attr_string(body, "comment", env)?;
         Ok(AstSchema {
             name: name.to_string(),
             alt_name,
             if_not_exists,
             authorization,
+            comment,
         })
     }
 
@@ -36,6 +38,7 @@ impl ForEachSupport for AstSequence {
         let schema = get_attr_string(body, "schema", env)?;
         let if_not_exists = get_attr_bool(body, "if_not_exists", env)?.unwrap_or(true);
         let r#as = get_attr_string(body, "as", env)?;
+        let comment = get_attr_string(body, "comment", env)?;
         let parse_i64 = |attr: &str| -> Result<Option<i64>> {
             match get_attr_string(body, attr, env)? {
                 Some(s) => Ok(Some(
@@ -65,6 +68,7 @@ impl ForEachSupport for AstSequence {
             cache,
             cycle,
             owned_by,
+            comment,
         })
     }
 
@@ -81,6 +85,7 @@ impl ForEachSupport for AstTable {
         let table_name = get_attr_string(body, "table_name", env)?;
         let schema = get_attr_string(body, "schema", env)?;
         let if_not_exists = get_attr_bool(body, "if_not_exists", env)?.unwrap_or(true);
+        let comment = get_attr_string(body, "comment", env)?;
 
         // columns
         let mut columns = Vec::new();
@@ -97,6 +102,7 @@ impl ForEachSupport for AstTable {
             let nullable = get_attr_bool(cb, "nullable", env)?.unwrap_or(true);
             let default = get_attr_string(cb, "default", env)?;
             let db_type = get_attr_string(cb, "db_type", env)?;
+            let comment = get_attr_string(cb, "comment", env)?;
             let lint_ignore = match find_attr(cb, "lint_ignore") {
                 Some(attr) => expr_to_string_vec(attr.expr(), env)?,
                 None => Vec::new(),
@@ -108,6 +114,7 @@ impl ForEachSupport for AstTable {
                 default,
                 db_type,
                 lint_ignore,
+                comment,
             });
         }
 
@@ -211,6 +218,7 @@ impl ForEachSupport for AstTable {
             foreign_keys: fks,
             back_references: Vec::new(),
             lint_ignore,
+            comment,
         })
     }
 
@@ -228,12 +236,14 @@ impl ForEachSupport for AstView {
         let schema = get_attr_string(body, "schema", env)?;
         let replace = get_attr_bool(body, "replace", env)?.unwrap_or(true);
         let sql = get_attr_string(body, "sql", env)?.context("view 'sql' is required")?;
+        let comment = get_attr_string(body, "comment", env)?;
         Ok(AstView {
             name: name.to_string(),
             alt_name,
             schema,
             replace,
             sql,
+            comment,
         })
     }
 
@@ -251,12 +261,14 @@ impl ForEachSupport for AstMaterializedView {
         let schema = get_attr_string(body, "schema", env)?;
         let with_data = get_attr_bool(body, "with_data", env)?.unwrap_or(true);
         let sql = get_attr_string(body, "sql", env)?.context("materialized 'sql' is required")?;
+        let comment = get_attr_string(body, "comment", env)?;
         Ok(AstMaterializedView {
             name: name.to_string(),
             alt_name,
             schema,
             with_data,
             sql,
+            comment,
         })
     }
 
@@ -281,6 +293,7 @@ impl ForEachSupport for AstPolicy {
         };
         let using = get_attr_string(body, "using", env)?;
         let check = get_attr_string(body, "check", env)?;
+        let comment = get_attr_string(body, "comment", env)?;
         Ok(AstPolicy {
             name: name.to_string(),
             alt_name,
@@ -291,6 +304,7 @@ impl ForEachSupport for AstPolicy {
             roles,
             using,
             check,
+            comment,
         })
     }
 
@@ -314,6 +328,7 @@ impl ForEachSupport for AstFunction {
         let schema = get_attr_string(body, "schema", env)?;
         let replace = get_attr_bool(body, "replace", env)?.unwrap_or(true);
         let security_definer = get_attr_bool(body, "security_definer", env)?.unwrap_or(false);
+        let comment = get_attr_string(body, "comment", env)?;
         Ok(AstFunction {
             name: name.to_string(),
             alt_name,
@@ -323,6 +338,7 @@ impl ForEachSupport for AstFunction {
             replace,
             security_definer,
             body: body_sql,
+            comment,
         })
     }
 
@@ -349,6 +365,7 @@ impl ForEachSupport for AstTrigger {
             get_attr_string(body, "function", env)?.context("trigger 'function' is required")?;
         let function_schema = get_attr_string(body, "function_schema", env)?;
         let when = get_attr_string(body, "when", env)?;
+        let comment = get_attr_string(body, "comment", env)?;
         Ok(AstTrigger {
             name: name.to_string(),
             alt_name,
@@ -360,6 +377,7 @@ impl ForEachSupport for AstTrigger {
             function,
             function_schema,
             when,
+            comment,
         })
     }
 
@@ -377,12 +395,14 @@ impl ForEachSupport for AstExtension {
         let if_not_exists = get_attr_bool(body, "if_not_exists", env)?.unwrap_or(true);
         let schema = get_attr_string(body, "schema", env)?;
         let version = get_attr_string(body, "version", env)?;
+        let comment = get_attr_string(body, "comment", env)?;
         Ok(AstExtension {
             name: name.to_string(),
             alt_name,
             if_not_exists,
             schema,
             version,
+            comment,
         })
     }
 
@@ -402,11 +422,13 @@ impl ForEachSupport for AstEnum {
             Some(attr) => expr_to_string_vec(attr.expr(), env)?,
             None => bail!("enum '{}' requires values = [..]", name),
         };
+        let comment = get_attr_string(body, "comment", env)?;
         Ok(AstEnum {
             name: name.to_string(),
             alt_name,
             schema,
             values,
+            comment,
         })
     }
 
@@ -428,6 +450,7 @@ impl ForEachSupport for AstDomain {
         let default = get_attr_string(body, "default", env)?;
         let constraint = get_attr_string(body, "constraint", env)?;
         let check = get_attr_string(body, "check", env)?;
+        let comment = get_attr_string(body, "comment", env)?;
         Ok(AstDomain {
             name: name.to_string(),
             alt_name,
@@ -437,6 +460,7 @@ impl ForEachSupport for AstDomain {
             default,
             constraint,
             check,
+            comment,
         })
     }
 
@@ -452,6 +476,7 @@ impl ForEachSupport for AstCompositeType {
     fn parse_one(name: &str, body: &Body, env: &EnvVars) -> Result<Self::Item> {
         let alt_name = get_attr_string(body, "name", env)?;
         let schema = get_attr_string(body, "schema", env)?;
+        let comment = get_attr_string(body, "comment", env)?;
         let mut fields = Vec::new();
         for fblk in body.blocks().filter(|bb| bb.identifier() == "field") {
             let fname = fblk
@@ -473,6 +498,7 @@ impl ForEachSupport for AstCompositeType {
             alt_name,
             schema,
             fields,
+            comment,
         })
     }
 
@@ -488,10 +514,12 @@ impl ForEachSupport for AstRole {
     fn parse_one(name: &str, body: &Body, env: &EnvVars) -> Result<Self::Item> {
         let alt_name = get_attr_string(body, "name", env)?;
         let login = get_attr_bool(body, "login", env)?.unwrap_or(false);
+        let comment = get_attr_string(body, "comment", env)?;
         Ok(AstRole {
             name: name.to_string(),
             alt_name,
             login,
+            comment,
         })
     }
 

--- a/src/ir/config.rs
+++ b/src/ir/config.rs
@@ -31,6 +31,7 @@ pub struct FunctionSpec {
     pub replace: bool,
     pub security_definer: bool,
     pub body: String,
+    pub comment: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -45,6 +46,7 @@ pub struct TriggerSpec {
     pub function: String,    // function name (unqualified)
     pub function_schema: Option<String>,
     pub when: Option<String>, // optional condition, raw SQL
+    pub comment: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -54,6 +56,7 @@ pub struct ExtensionSpec {
     pub if_not_exists: bool,
     pub schema: Option<String>,
     pub version: Option<String>,
+    pub comment: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -70,6 +73,7 @@ pub struct SequenceSpec {
     pub cache: Option<i64>,
     pub cycle: bool,
     pub owned_by: Option<String>,
+    pub comment: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -78,6 +82,7 @@ pub struct SchemaSpec {
     pub alt_name: Option<String>,
     pub if_not_exists: bool,
     pub authorization: Option<String>,
+    pub comment: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -86,6 +91,7 @@ pub struct EnumSpec {
     pub alt_name: Option<String>,
     pub schema: Option<String>,
     pub values: Vec<String>,
+    pub comment: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -98,6 +104,7 @@ pub struct DomainSpec {
     pub default: Option<String>,
     pub constraint: Option<String>,
     pub check: Option<String>,
+    pub comment: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -106,6 +113,7 @@ pub struct CompositeTypeSpec {
     pub alt_name: Option<String>,
     pub schema: Option<String>,
     pub fields: Vec<CompositeTypeFieldSpec>,
+    pub comment: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -121,6 +129,7 @@ pub struct ViewSpec {
     pub schema: Option<String>,
     pub replace: bool, // OR REPLACE
     pub sql: String,   // SELECT ... body
+    pub comment: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -130,6 +139,7 @@ pub struct MaterializedViewSpec {
     pub schema: Option<String>,
     pub with_data: bool, // WITH [NO] DATA
     pub sql: String,     // SELECT ... body
+    pub comment: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -143,6 +153,7 @@ pub struct PolicySpec {
     pub roles: Vec<String>,    // empty => PUBLIC (omit TO clause)
     pub using: Option<String>, // USING (expr)
     pub check: Option<String>, // WITH CHECK (expr)
+    pub comment: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -150,6 +161,7 @@ pub struct RoleSpec {
     pub name: String,
     pub alt_name: Option<String>,
     pub login: bool,
+    pub comment: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -174,6 +186,7 @@ pub struct TableSpec {
     pub foreign_keys: Vec<ForeignKeySpec>,
     pub back_references: Vec<BackReferenceSpec>,
     pub lint_ignore: Vec<String>,
+    pub comment: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -190,6 +203,7 @@ pub struct ColumnSpec {
     pub default: Option<String>,
     pub db_type: Option<String>, // NEW: Database-specific type like "CHAR(32)", "VARCHAR(255)"
     pub lint_ignore: Vec<String>,
+    pub comment: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,11 +2,11 @@ pub mod backends;
 pub mod config;
 pub mod frontend;
 pub mod ir;
+pub mod lint;
 pub mod passes;
 pub mod postgres;
 pub mod prisma;
 pub mod test_runner;
-pub mod lint;
 
 use anyhow::Result;
 // Keep types public via re-exports
@@ -596,6 +596,7 @@ mod tests {
                 replace: false,
                 security_definer: false,
                 body: String::new(),
+                comment: None,
             }],
             tables: vec![TableSpec {
                 name: "t".into(),
@@ -608,6 +609,7 @@ mod tests {
                 foreign_keys: vec![],
                 back_references: vec![],
                 lint_ignore: vec![],
+                comment: None,
             }],
             ..Default::default()
         };
@@ -633,6 +635,7 @@ mod tests {
                 replace: false,
                 security_definer: false,
                 body: String::new(),
+                comment: None,
             }],
             tables: vec![TableSpec {
                 name: "t".into(),
@@ -645,6 +648,7 @@ mod tests {
                 foreign_keys: vec![],
                 back_references: vec![],
                 lint_ignore: vec![],
+                comment: None,
             }],
             ..Default::default()
         };


### PR DESCRIPTION
## Summary
- allow specifying optional `comment` on functions, tables, columns and other schema objects
- parse `comment` attributes and carry them through lowering to IR
- emit `COMMENT ON` statements for supported objects in the Postgres backend

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b739aba5508331a3424716dfea64fa