### PR TITLE
Add tasks for running examples

### DIFF
--- a/justfile
+++ b/justfile
@@ -28,3 +28,32 @@ example-test dsn='postgres://postgres:postgres@localhost:5432/dbschema_dev':
   echo "Running tests via cargo..."
   cargo run -- --input examples/main.hcl test --dsn "{{dsn}}"
 
+# Run create-migration for all example HCL files
+examples-create-migration:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  for example in examples/*.hcl; do
+    name=$(basename "$example" .hcl)
+    outdir="tmp_mig_${name}"
+    rm -rf "$outdir"
+    mkdir -p "$outdir"
+    cargo run --features pglite -- --input "$example" create-migration --out-dir "$outdir" --name "$name"
+    rm -rf "$outdir"
+  done
+
+# Run tests for all example HCL files using the PGlite backend
+examples-test:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  for example in examples/*.hcl; do
+    cargo run --features pglite -- --input "$example" test --backend pglite
+  done
+
+# Validate all example HCL files
+examples-validate:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  for example in examples/*.hcl; do
+    cargo run --features pglite -- --input "$example" validate
+  done
+


### PR DESCRIPTION
## Summary
- add just tasks to generate migrations, run tests, and validate all example HCL files

## Testing
- `just pglite-assets`
- `cargo test --features pglite` *(fails: unknown import `env::emscripten_asm_const_int`)*
- `just examples-validate` *(fails: HCL parse error in examples/locals.hcl)*
- `just examples-test` *(fails: unknown import `env::emscripten_asm_const_int`)*
- `just examples-create-migration` *(fails: HCL parse error in examples/locals.hcl)*

------
https://chatgpt.com/codex/tasks/task_e_68b73be7189c8331ba6c16ec3c920d01