### PR TITLE
feat: replace wasmtime with wasmer

### DIFF
--- a/crates/pglite/Cargo.toml
+++ b/crates/pglite/Cargo.toml
@@ -8,5 +8,5 @@ anyhow = "1"
 bytes = "1"
 fallible-iterator = "0.2"
 postgres-protocol = "0.6"
-wasmtime = "36"
-wasmtime-wasi = { version = "36", features=["preview1"] }
+wasmer = "4"
+wasmer-emscripten = "4"


### PR DESCRIPTION
## Summary
- switch pglite crate from wasmtime to wasmer with Emscripten runtime
- initialize Wasmer Emscripten environment and run pglite functions

## Testing
- `cargo test -p pglite`
- `cargo test --features pglite` *(fails: linking with `cc` failed: undefined reference to `__rust_probestack`)*

------
https://chatgpt.com/codex/tasks/task_e_68b73fa2d74c8331af3b9c557c76a17a