### PR TITLE
Add WASI integration for PGlite runtime

### DIFF
--- a/crates/pglite/Cargo.toml
+++ b/crates/pglite/Cargo.toml
@@ -8,5 +8,6 @@ anyhow = "1"
 bytes = "1"
 fallible-iterator = "0.2"
 postgres-protocol = "0.6"
-wasmer = "4"
-wasmer-emscripten = "4"
+wasmer = "5.0.0-rc.1"
+wasmer-emscripten = "5.0.0-rc.1"
+wasmer-wasix = { version = "0.29.0", default-features = false, features = ["sys-default"] }


### PR DESCRIPTION
## Summary
- integrate WasiEnv with Emscripten setup in PGlite runtime
- pull in `wasmer-wasix` with WASI support

## Testing
- `cargo test --test pglite_backend --features pglite` *(fails: there is no reactor running, must be called from the context of a Tokio runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68b747ec58d08331a35b1afe16bdadbd