### PR TITLE
Start Tokio runtime for PGlite commands

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ postgres-protocol = { version = "0.6", optional = true }
 bytes = { version = "1", optional = true }
 fallible-iterator = { version = "0.2", optional = true }
 pglite = { path = "crates/pglite", optional = true }
+tokio = { version = "1", features = ["rt-multi-thread"], optional = true }
 
 [dev-dependencies]
 tempfile = "3"
@@ -38,7 +39,7 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 
 [features]
 default = []
-pglite = ["dep:pglite", "postgres-protocol", "bytes", "fallible-iterator"]
+pglite = ["dep:pglite", "postgres-protocol", "bytes", "fallible-iterator", "tokio"]
 
 [profile.release]
 opt-level = 3

--- a/src/main.rs
+++ b/src/main.rs
@@ -343,6 +343,14 @@ fn main() -> Result<()> {
                 } else {
                     Some(names.into_iter().collect())
                 };
+                #[cfg(feature = "pglite")]
+                let summary = if matches!(backend, TestBackendKind::Pglite) {
+                    tokio::runtime::Runtime::new()?
+                        .block_on(async { runner.run(&config, &dsn, only.as_ref()) })?
+                } else {
+                    runner.run(&config, &dsn, only.as_ref())?
+                };
+                #[cfg(not(feature = "pglite"))]
                 let summary = runner.run(&config, &dsn, only.as_ref())?;
                 for r in summary.results {
                     if r.passed {
@@ -368,51 +376,56 @@ fn main() -> Result<()> {
             #[cfg(feature = "pglite")]
             Commands::Pglite {} => {
                 use std::io::{self, Write};
-                let mut rt = dbschema::test_runner::pglite::PGliteRuntime::new()?;
-                rt.startup()?;
-                let stdin = io::stdin();
-                let mut line = String::new();
-                loop {
-                    print!("pglite=> ");
-                    io::stdout().flush()?;
-                    line.clear();
-                    if stdin.read_line(&mut line)? == 0 {
-                        break;
-                    }
-                    let sql = line.trim();
-                    if sql.eq_ignore_ascii_case("\\q") {
-                        break;
-                    }
-                    match rt.simple_query(sql) {
-                        Ok(msgs) => {
-                            for m in msgs {
-                                if let backend::Message::DataRow(row) = m {
-                                    let buf = row.buffer();
-                                    let mut fields = row.ranges();
-                                    let mut out = Vec::new();
-                                    while let Some(res) = fields.next()? {
-                                        match res {
-                                            Some(range) => {
-                                                let val = &buf[range];
-                                                out.push(String::from_utf8_lossy(val).to_string());
+                tokio::runtime::Runtime::new()?.block_on(async {
+                    let mut pg = dbschema::test_runner::pglite::PGliteRuntime::new()?;
+                    pg.startup()?;
+                    let stdin = io::stdin();
+                    let mut line = String::new();
+                    loop {
+                        print!("pglite=> ");
+                        io::stdout().flush()?;
+                        line.clear();
+                        if stdin.read_line(&mut line)? == 0 {
+                            break;
+                        }
+                        let sql = line.trim();
+                        if sql.eq_ignore_ascii_case("\\q") {
+                            break;
+                        }
+                        match pg.simple_query(sql) {
+                            Ok(msgs) => {
+                                for m in msgs {
+                                    if let backend::Message::DataRow(row) = m {
+                                        let buf = row.buffer();
+                                        let mut fields = row.ranges();
+                                        let mut out = Vec::new();
+                                        while let Some(res) = fields.next()? {
+                                            match res {
+                                                Some(range) => {
+                                                    let val = &buf[range];
+                                                    out.push(
+                                                        String::from_utf8_lossy(val).to_string(),
+                                                    );
+                                                }
+                                                None => out.push("NULL".into()),
                                             }
-                                            None => out.push("NULL".into()),
                                         }
-                                    }
-                                    println!("{}", out.join(" | "));
-                                } else if let backend::Message::CommandComplete(c) = m {
-                                    if let Ok(tag) = c.tag() {
-                                        println!("{}", tag);
-                                    } else {
-                                        println!("<command complete>");
+                                        println!("{}", out.join(" | "));
+                                    } else if let backend::Message::CommandComplete(c) = m {
+                                        if let Ok(tag) = c.tag() {
+                                            println!("{}", tag);
+                                        } else {
+                                            println!("<command complete>");
+                                        }
                                     }
                                 }
                             }
+                            Err(e) => eprintln!("error: {e}"),
                         }
-                        Err(e) => eprintln!("error: {e}"),
                     }
-                }
-                rt.shutdown()?;
+                    pg.shutdown()?;
+                    Ok::<(), anyhow::Error>(())
+                })?;
             }
         }
     }


### PR DESCRIPTION
## Summary
- enable Tokio runtime when using the PGlite backend and REPL
- add optional Tokio dependency and wire to pglite feature

## Testing
- `cargo test --test pglite_backend --features pglite`


------
https://chatgpt.com/codex/tasks/task_e_68b86603107c8331a9b872b1a925f150