### PR TITLE
Add event trigger support

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ test_backend = "pglite"
 - Lint schema: `./target/release/dbschema --input examples/main.hcl lint`
 - Variables: `--var schema=public` or `--var-file .env.hcl`
 - Using config file: `dbschema --config` or `dbschema --config --target <target_name>`
+- Event triggers: see `examples/event_trigger.hcl`
 
 
 ## Linting
@@ -345,7 +346,7 @@ module "<name>" {
 - Control which resources are included per run:
   - `--include tables --include functions` (repeatable)
   - `--exclude tables` (repeatable)
-  - Resource kinds: `schemas, sequences, enums, tables, views, materialized, functions, triggers, extensions, policies, tests`
+  - Resource kinds: `schemas, sequences, enums, tables, views, materialized, functions, triggers, event_triggers, extensions, policies, tests`
 - Example split-output workflow:
   - Prisma models for tables: `dbschema --backend prisma --include tables --input examples/main.hcl create-migration --out-dir prisma --name schema`
   - SQL for everything else: `dbschema --backend postgres --exclude tables --input examples/main.hcl create-migration --out-dir migrations --name non_tables`

--- a/examples/event_trigger.hcl
+++ b/examples/event_trigger.hcl
@@ -1,0 +1,15 @@
+function "ddl_logger" {
+  language = "plpgsql"
+  returns  = "event_trigger"
+  body = <<-SQL
+    BEGIN
+      -- handle ddl start
+    END;
+  SQL
+}
+
+event_trigger "log_ddl" {
+  event = "ddl_command_start"
+  tags  = ["CREATE TABLE"]
+  function = "ddl_logger"
+}

--- a/src/backends/postgres.rs
+++ b/src/backends/postgres.rs
@@ -196,6 +196,18 @@ fn to_sql(cfg: &Config) -> Result<String> {
         }
     }
 
+    for e in &cfg.event_triggers {
+        out.push_str(&format!("{}\n\n", pg::EventTrigger::from(e)));
+        if let Some(comment) = &e.comment {
+            let name = e.alt_name.clone().unwrap_or_else(|| e.name.clone());
+            out.push_str(&format!(
+                "COMMENT ON EVENT TRIGGER {} IS {};\n\n",
+                pg::ident(&name),
+                pg::literal(comment)
+            ));
+        }
+    }
+
     for t in &cfg.triggers {
         out.push_str(&format!("{}\n\n", pg::Trigger::from(t)));
         if let Some(comment) = &t.comment {

--- a/src/config.rs
+++ b/src/config.rs
@@ -82,6 +82,7 @@ pub enum ResourceKind {
     Materialized,
     Functions,
     Triggers,
+    EventTriggers,
     Extensions,
     Sequences,
     Policies,
@@ -102,6 +103,7 @@ impl fmt::Display for ResourceKind {
             ResourceKind::Materialized => "materialized",
             ResourceKind::Functions => "functions",
             ResourceKind::Triggers => "triggers",
+            ResourceKind::EventTriggers => "event_triggers",
             ResourceKind::Extensions => "extensions",
             ResourceKind::Sequences => "sequences",
             ResourceKind::Policies => "policies",
@@ -127,6 +129,7 @@ impl std::str::FromStr for ResourceKind {
             "materialized" => Ok(ResourceKind::Materialized),
             "functions" => Ok(ResourceKind::Functions),
             "triggers" => Ok(ResourceKind::Triggers),
+            "event_triggers" => Ok(ResourceKind::EventTriggers),
             "extensions" => Ok(ResourceKind::Extensions),
             "sequences" => Ok(ResourceKind::Sequences),
             "policies" => Ok(ResourceKind::Policies),
@@ -153,6 +156,7 @@ impl TargetConfig {
                 ResourceKind::Materialized,
                 ResourceKind::Functions,
                 ResourceKind::Triggers,
+                ResourceKind::EventTriggers,
                 ResourceKind::Extensions,
                 ResourceKind::Sequences,
                 ResourceKind::Policies,
@@ -223,7 +227,8 @@ mod tests {
         let include_set = target.get_include_set();
         assert!(include_set.contains(&ResourceKind::Tables));
         assert!(include_set.contains(&ResourceKind::Enums));
-        assert_eq!(include_set.len(), 15); // All resource types
+        assert!(include_set.contains(&ResourceKind::EventTriggers));
+        assert_eq!(include_set.len(), 16); // All resource types
     }
 
     #[test]
@@ -268,5 +273,6 @@ mod tests {
         assert!(!exclude_set.contains(&ResourceKind::Tables));
         assert!(exclude_set.contains(&ResourceKind::Functions));
         assert!(exclude_set.contains(&ResourceKind::Triggers));
+        assert!(!exclude_set.contains(&ResourceKind::EventTriggers));
     }
 }

--- a/src/frontend/ast/mod.rs
+++ b/src/frontend/ast/mod.rs
@@ -4,6 +4,7 @@ use hcl::{Expression, Value};
 pub struct Config {
     pub functions: Vec<AstFunction>,
     pub triggers: Vec<AstTrigger>,
+    pub event_triggers: Vec<AstEventTrigger>,
     pub extensions: Vec<AstExtension>,
     pub sequences: Vec<AstSequence>,
     pub schemas: Vec<AstSchema>,
@@ -45,6 +46,17 @@ pub struct AstTrigger {
     pub function: String,
     pub function_schema: Option<String>,
     pub when: Option<String>,
+    pub comment: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AstEventTrigger {
+    pub name: String,
+    pub alt_name: Option<String>,
+    pub event: String,
+    pub tags: Vec<String>,
+    pub function: String,
+    pub function_schema: Option<String>,
     pub comment: Option<String>,
 }
 

--- a/src/frontend/lower.rs
+++ b/src/frontend/lower.rs
@@ -5,6 +5,7 @@ pub fn lower_config(ast: ast::Config) -> ir::Config {
     ir::Config {
         functions: ast.functions.into_iter().map(Into::into).collect(),
         triggers: ast.triggers.into_iter().map(Into::into).collect(),
+        event_triggers: ast.event_triggers.into_iter().map(Into::into).collect(),
         extensions: ast.extensions.into_iter().map(Into::into).collect(),
         sequences: ast.sequences.into_iter().map(Into::into).collect(),
         schemas: ast.schemas.into_iter().map(Into::into).collect(),
@@ -51,6 +52,20 @@ impl From<ast::AstTrigger> for ir::TriggerSpec {
             function: t.function,
             function_schema: t.function_schema,
             when: t.when,
+            comment: t.comment,
+        }
+    }
+}
+
+impl From<ast::AstEventTrigger> for ir::EventTriggerSpec {
+    fn from(t: ast::AstEventTrigger) -> Self {
+        Self {
+            name: t.name,
+            alt_name: t.alt_name,
+            event: t.event,
+            tags: t.tags,
+            function: t.function,
+            function_schema: t.function_schema,
             comment: t.comment,
         }
     }

--- a/src/frontend/resource_impls.rs
+++ b/src/frontend/resource_impls.rs
@@ -386,6 +386,38 @@ impl ForEachSupport for AstTrigger {
     }
 }
 
+// EventTrigger implementation
+impl ForEachSupport for AstEventTrigger {
+    type Item = Self;
+
+    fn parse_one(name: &str, body: &Body, env: &EnvVars) -> Result<Self::Item> {
+        let alt_name = get_attr_string(body, "name", env)?;
+        let event =
+            get_attr_string(body, "event", env)?.context("event_trigger 'event' is required")?;
+        let tags = match find_attr(body, "tags") {
+            Some(attr) => expr_to_string_vec(attr.expr(), env)?,
+            None => Vec::new(),
+        };
+        let function = get_attr_string(body, "function", env)?
+            .context("event_trigger 'function' is required")?;
+        let function_schema = get_attr_string(body, "function_schema", env)?;
+        let comment = get_attr_string(body, "comment", env)?;
+        Ok(AstEventTrigger {
+            name: name.to_string(),
+            alt_name,
+            event,
+            tags,
+            function,
+            function_schema,
+            comment,
+        })
+    }
+
+    fn add_to_config(item: Self::Item, config: &mut Config) {
+        config.event_triggers.push(item);
+    }
+}
+
 // Extension implementation
 impl ForEachSupport for AstExtension {
     type Item = Self;

--- a/src/ir/config.rs
+++ b/src/ir/config.rs
@@ -5,6 +5,7 @@ use serde::Serialize;
 pub struct Config {
     pub functions: Vec<FunctionSpec>,
     pub triggers: Vec<TriggerSpec>,
+    pub event_triggers: Vec<EventTriggerSpec>,
     pub extensions: Vec<ExtensionSpec>,
     pub sequences: Vec<SequenceSpec>,
     pub schemas: Vec<SchemaSpec>,
@@ -46,6 +47,17 @@ pub struct TriggerSpec {
     pub function: String,    // function name (unqualified)
     pub function_schema: Option<String>,
     pub when: Option<String>, // optional condition, raw SQL
+    pub comment: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct EventTriggerSpec {
+    pub name: String,
+    pub alt_name: Option<String>,
+    pub event: String,
+    pub tags: Vec<String>,
+    pub function: String,
+    pub function_schema: Option<String>,
     pub comment: Option<String>,
 }
 

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -2,7 +2,7 @@ pub mod config;
 
 pub use config::{
     BackReferenceSpec, ColumnSpec, CompositeTypeFieldSpec, CompositeTypeSpec, Config, DomainSpec,
-    EnumSpec, ExtensionSpec, ForeignKeySpec, FunctionSpec, GrantSpec, IndexSpec,
+    EnumSpec, EventTriggerSpec, ExtensionSpec, ForeignKeySpec, FunctionSpec, GrantSpec, IndexSpec,
     MaterializedViewSpec, OutputSpec, PolicySpec, PrimaryKeySpec, RoleSpec, SchemaSpec,
     SequenceSpec, TableSpec, TestSpec, TriggerSpec, ViewSpec,
 };

--- a/src/passes/validate.rs
+++ b/src/passes/validate.rs
@@ -21,6 +21,24 @@ pub fn validate(cfg: &Config, strict: bool) -> Result<()> {
         }
     }
 
+    for t in &cfg.event_triggers {
+        let fqn = format!(
+            "{}.{}",
+            t.function_schema.as_deref().unwrap_or("public"),
+            t.function
+        );
+        let found = cfg.functions.iter().any(|f| {
+            let fs = f.schema.as_deref().unwrap_or("public");
+            f.name == t.function && (t.function_schema.as_deref().unwrap_or(fs) == fs)
+        });
+        if !found {
+            bail!(
+                "event trigger '{}' references missing function '{}': ensure function exists or set function_schema",
+                t.name, fqn
+            );
+        }
+    }
+
     if strict {
         for table in &cfg.tables {
             for column in &table.columns {


### PR DESCRIPTION
## Summary
- support event triggers via `AstEventTrigger` and `EventTriggerSpec`
- generate `CREATE EVENT TRIGGER` SQL in Postgres backend
- document and test new event trigger resource

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b93988edd88331b56c305ccb427104