### PR TITLE
feat: extend lint rules and severity config

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ test_backend = "pglite"
 - `naming-convention`: table and column names must be `snake_case`.
 - `missing-index`: tables should define at least one index or primary key.
 
+- `forbid-serial`: disallow use of `serial`/`bigserial` column types.
+- `primary-key-not-null`: columns in a primary key must be `NOT NULL`.
+
 Suppress a rule for a specific table or column with `lint_ignore`:
 
 ```hcl
@@ -110,6 +113,16 @@ table "users" {
   }
 }
 ```
+
+Configure rule severity globally in `dbschema.toml`:
+
+```toml
+[settings.lint.severity]
+missing-index = "warn"
+forbid-serial = "error"
+```
+
+Setting a rule's severity to `allow` suppresses it entirely.
 
 ## Logging
 

--- a/dbschema.toml
+++ b/dbschema.toml
@@ -10,6 +10,10 @@ var_files = ["vars.tfvars"]
 # Environment variables to set
 env = { DATABASE_URL = "postgres://localhost:5432/mydb" }
 
+[settings.lint.severity]
+missing-index = "warn"
+forbid-serial = "error"
+
 # Target definitions
 [[targets]]
 name = "postgres_schema"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use crate::lint::LintSettings;
 use anyhow::Result;
 use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
@@ -22,6 +23,9 @@ pub struct Settings {
     /// Default DSN for `dbschema test`
     #[serde(default)]
     pub test_dsn: Option<String>,
+    /// Lint configuration
+    #[serde(default)]
+    pub lint: LintSettings,
 }
 
 /// Configuration for a single target output


### PR DESCRIPTION
## Summary
- add severity levels and new lint checks
- allow rule severity overrides via `dbschema.toml`
- document lint suppression and severity configuration

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b939c4141c8331866db4bbdbc85400