### PR TITLE
docs: split README into dedicated guides

### DIFF
--- a/docs/locals.md
+++ b/docs/locals.md
@@ -1,0 +1,17 @@
+# Locals
+
+`locals` define named expressions that can be referenced throughout the configuration using `local.<name>`.
+
+```hcl
+locals {
+  schema = "public"
+  table  = "users"
+}
+
+table "users" {
+  schema = local.schema
+  column "id" { type = "serial", nullable = false }
+}
+```
+
+Locals are evaluated once and are useful for computed values or to avoid repeating literals.

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -1,0 +1,14 @@
+# Modules
+
+Modules allow reusing groups of resources. A module points to a directory containing a `main.hcl` file and passes in variables.
+
+```hcl
+module "timestamps" {
+  source = "./modules/timestamps"
+  schema = "public"
+  table  = "orders"
+  column = "updated_at"
+}
+```
+
+Inside the module, variables provided by the caller are accessible via `var.<name>`. Modules can themselves declare outputs to expose values back to the parent configuration.

--- a/docs/output.md
+++ b/docs/output.md
@@ -1,0 +1,13 @@
+# Output
+
+`output` blocks expose values from a configuration or module so they can be consumed elsewhere.
+
+```hcl
+variable "count" { default = 1 }
+
+output "count" {
+  value = var.count
+}
+```
+
+Outputs are printed after evaluation and can be referenced by parent modules.

--- a/docs/postgres/domain.md
+++ b/docs/postgres/domain.md
@@ -1,0 +1,20 @@
+# Domain
+
+Defines a custom domain built on top of a base type with optional constraints.
+
+```hcl
+domain "email" {
+  type = "text"
+  check = "VALUE ~* '^[^@]+@[^@]+$'"
+}
+```
+
+## Attributes
+- `name` (label): domain name.
+- `schema` (string, optional): schema for the domain. Defaults to `public`.
+- `type` (string): underlying data type.
+- `not_null` (bool, optional): add `NOT NULL` constraint.
+- `default` (string, optional): default value expression.
+- `constraint` (string, optional): name of a constraint.
+- `check` (string, optional): `CHECK` expression using `VALUE`.
+- `comment` (string, optional): documentation comment.

--- a/docs/postgres/enum.md
+++ b/docs/postgres/enum.md
@@ -1,0 +1,16 @@
+# Enum
+
+Creates a PostgreSQL enum type with a fixed set of values.
+
+```hcl
+enum "status" {
+  schema = "public"
+  values = ["active", "disabled"]
+}
+```
+
+## Attributes
+- `name` (label): enum type name.
+- `schema` (string, optional): schema for the type. Defaults to `public`.
+- `values` (array of strings): ordered list of allowed values.
+- `comment` (string, optional): documentation comment.

--- a/docs/postgres/event_trigger.md
+++ b/docs/postgres/event_trigger.md
@@ -1,0 +1,19 @@
+# Event Trigger
+
+Fires a function in response to database-wide events.
+
+```hcl
+event_trigger "log_ddl" {
+  event   = "ddl_command_start"
+  tags    = ["CREATE TABLE"]
+  function = "ddl_logger"
+}
+```
+
+## Attributes
+- `name` (label): trigger name.
+- `event` (string): event name such as `ddl_command_start`.
+- `tags` (array of strings): optional filter on `TAG IN (...)`.
+- `function` (string): function to execute.
+- `function_schema` (string, optional): schema of the function.
+- `comment` (string, optional): documentation comment.

--- a/docs/postgres/extension.md
+++ b/docs/postgres/extension.md
@@ -1,0 +1,16 @@
+# Extension
+
+Installs a PostgreSQL extension.
+
+```hcl
+extension "pgcrypto" {
+  if_not_exists = true
+}
+```
+
+## Attributes
+- `name` (label): extension name.
+- `if_not_exists` (bool, optional): emit `IF NOT EXISTS` (defaults to true).
+- `schema` (string, optional): target schema for extension objects.
+- `version` (string, optional): specific version to install.
+- `comment` (string, optional): documentation comment.

--- a/docs/postgres/function.md
+++ b/docs/postgres/function.md
@@ -1,0 +1,23 @@
+# Function
+
+Creates a user-defined function.
+
+```hcl
+function "now_utc" {
+  schema   = "public"
+  language = "sql"
+  returns  = "timestamptz"
+  replace  = true
+  body     = "SELECT now()"
+}
+```
+
+## Attributes
+- `name` (label): function name.
+- `schema` (string, optional): schema for the function. Defaults to `public`.
+- `language` (string): implementation language.
+- `returns` (string): return type.
+- `replace` (bool, optional): use `CREATE OR REPLACE`.
+- `security_definer` (bool, optional): run as definer instead of invoker.
+- `body` (string): function body.
+- `comment` (string, optional): documentation comment.

--- a/docs/postgres/grant.md
+++ b/docs/postgres/grant.md
@@ -1,0 +1,20 @@
+# Grant
+
+Grants privileges to a role on database objects.
+
+```hcl
+grant "app_user_tables" {
+  role       = "app_user"
+  privileges = ["SELECT"]
+  schema     = "public"
+  table      = "users"
+}
+```
+
+## Attributes
+- `name` (label): identifier for the grant.
+- `role` (string): role receiving the privileges.
+- `privileges` (array of strings): privileges such as `SELECT`, `INSERT`, etc.
+- `schema` (string, optional): schema containing the object.
+- `table` (string, optional): table name.
+- `function` (string, optional): function name.

--- a/docs/postgres/index.md
+++ b/docs/postgres/index.md
@@ -1,0 +1,18 @@
+# Index
+
+Defines an index on an existing table.
+
+```hcl
+index "users_email_key" {
+  table   = "users"
+  columns = ["email"]
+  unique  = true
+}
+```
+
+## Attributes
+- `name` (label): index name.
+- `table` (string): table to index.
+- `schema` (string, optional): schema of the table. Defaults to `public`.
+- `columns` (array of strings): columns to include.
+- `unique` (bool, optional): create a unique index.

--- a/docs/postgres/materialized.md
+++ b/docs/postgres/materialized.md
@@ -1,0 +1,20 @@
+# Materialized View
+
+Defines a materialized view that stores query results.
+
+```hcl
+materialized "user_counts" {
+  schema    = "public"
+  with_data = true
+  sql = <<-SQL
+    SELECT 1 as id
+  SQL
+}
+```
+
+## Attributes
+- `name` (label): view name.
+- `schema` (string, optional): schema for the view. Defaults to `public`.
+- `with_data` (bool, optional): include `WITH DATA` (default) or `WITH NO DATA`.
+- `sql` (string): SELECT statement defining the view.
+- `comment` (string, optional): documentation comment.

--- a/docs/postgres/policy.md
+++ b/docs/postgres/policy.md
@@ -1,0 +1,24 @@
+# Policy
+
+Defines a row-level security policy.
+
+```hcl
+policy "user_select" {
+  schema  = "public"
+  table   = "users"
+  command = "select"
+  roles   = ["postgres"]
+  using   = "true"
+}
+```
+
+## Attributes
+- `name` (label): policy name.
+- `schema` (string, optional): schema of the table. Defaults to `public`.
+- `table` (string): table the policy applies to.
+- `command` (string): `ALL`, `SELECT`, `INSERT`, `UPDATE`, or `DELETE`.
+- `as` (string, optional): `PERMISSIVE` or `RESTRICTIVE`.
+- `roles` (array of strings): roles the policy applies to. Empty means `PUBLIC`.
+- `using` (string, optional): expression for row visibility.
+- `check` (string, optional): expression for permitted values on write.
+- `comment` (string, optional): documentation comment.

--- a/docs/postgres/role.md
+++ b/docs/postgres/role.md
@@ -1,0 +1,14 @@
+# Role
+
+Creates a database role.
+
+```hcl
+role "app_user" {
+  login = false
+}
+```
+
+## Attributes
+- `name` (label): role name.
+- `login` (bool, optional): allow login. Defaults to `false`.
+- `comment` (string, optional): documentation comment.

--- a/docs/postgres/schema.md
+++ b/docs/postgres/schema.md
@@ -1,0 +1,16 @@
+# Schema
+
+Defines a database schema. Optional attributes control existence checks and ownership.
+
+```hcl
+schema "analytics" {
+  if_not_exists = true
+  authorization = "app_user"
+}
+```
+
+## Attributes
+- `name` (label): schema name.
+- `if_not_exists` (bool): emit `CREATE SCHEMA IF NOT EXISTS` when true. Defaults to `false`.
+- `authorization` (string, optional): owner of the schema.
+- `comment` (string, optional): documentation comment.

--- a/docs/postgres/sequence.md
+++ b/docs/postgres/sequence.md
@@ -1,0 +1,26 @@
+# Sequence
+
+Defines an auto-incrementing sequence.
+
+```hcl
+sequence "user_id_seq" {
+  schema    = "public"
+  as        = "bigint"
+  increment = 1
+  min_value = 1
+  start     = 1
+  cache     = 1
+  cycle     = false
+  owned_by  = "users.id"
+}
+```
+
+## Attributes
+- `name` (label): sequence name.
+- `schema` (string, optional): schema for the sequence. Defaults to `public`.
+- `if_not_exists` (bool, optional): emit `IF NOT EXISTS`.
+- `as` (string, optional): data type of the sequence.
+- `increment`, `min_value`, `max_value`, `start`, `cache` (numbers, optional): control sequence behavior.
+- `cycle` (bool, optional): wrap around when reaching limits.
+- `owned_by` (string, optional): table column this sequence is owned by.
+- `comment` (string, optional): documentation comment.

--- a/docs/postgres/table.md
+++ b/docs/postgres/table.md
@@ -1,0 +1,36 @@
+# Table
+
+Creates a table with columns and constraints.
+
+```hcl
+table "users" {
+  schema       = "public"
+  if_not_exists = true
+
+  column "id" {
+    type     = "serial"
+    nullable = false
+  }
+
+  column "email" {
+    type     = "text"
+    nullable = false
+  }
+
+  primary_key { columns = ["id"] }
+  check "email_not_empty" { expression = "email <> ''" }
+}
+```
+
+## Attributes
+- `name` (label): table name.
+- `schema` (string, optional): schema for the table. Defaults to `public`.
+- `if_not_exists` (bool, optional): emit `IF NOT EXISTS`.
+- `column` blocks: define columns with `type`, `nullable`, optional `default`, `db_type`, `lint_ignore`, `comment`.
+- `primary_key` block: list of column names and optional constraint name.
+- `check` blocks: named check constraints with an `expression`.
+- `index` blocks: inline index definitions (`columns`, `unique`).
+- `foreign_key` blocks: reference other tables with `columns`, `ref_schema`, `ref_table`, `ref_columns`, `on_delete`, `on_update`.
+- `back_reference` blocks: create foreign keys on another table.
+- `lint_ignore` (array of strings, optional): suppress lint rules.
+- `comment` (string, optional): documentation comment.

--- a/docs/postgres/trigger.md
+++ b/docs/postgres/trigger.md
@@ -1,0 +1,26 @@
+# Trigger
+
+Attaches a function to table events.
+
+```hcl
+trigger "users_updated_at" {
+  schema   = "public"
+  table    = "users"
+  timing   = "BEFORE"
+  events   = ["UPDATE"]
+  level    = "ROW"
+  function = "set_updated_at"
+}
+```
+
+## Attributes
+- `name` (label): trigger name.
+- `schema` (string, optional): schema for the trigger. Defaults to `public`.
+- `table` (string): table the trigger operates on.
+- `timing` (string): `BEFORE` or `AFTER`.
+- `events` (array of strings): `INSERT`, `UPDATE`, `DELETE`.
+- `level` (string): `ROW` or `STATEMENT`.
+- `function` (string): function name to execute.
+- `function_schema` (string, optional): schema of the function.
+- `when` (string, optional): optional WHEN condition.
+- `comment` (string, optional): documentation comment.

--- a/docs/postgres/type.md
+++ b/docs/postgres/type.md
@@ -1,0 +1,16 @@
+# Composite Type
+
+Defines a custom composite type with named fields.
+
+```hcl
+type "address" {
+  field "street" { type = "text" }
+  field "zip"    { type = "int" }
+}
+```
+
+## Attributes
+- `name` (label): type name.
+- `schema` (string, optional): schema for the type. Defaults to `public`.
+- `field` blocks: each adds a field with a `type`.
+- `comment` (string, optional): documentation comment.

--- a/docs/postgres/view.md
+++ b/docs/postgres/view.md
@@ -1,0 +1,20 @@
+# View
+
+Creates a SQL view.
+
+```hcl
+view "active_users" {
+  schema  = "public"
+  replace = true
+  sql = <<-SQL
+    SELECT id, email FROM public.users
+  SQL
+}
+```
+
+## Attributes
+- `name` (label): view name.
+- `schema` (string, optional): schema for the view. Defaults to `public`.
+- `replace` (bool, optional): use `CREATE OR REPLACE VIEW`.
+- `sql` (string): SELECT statement defining the view.
+- `comment` (string, optional): documentation comment.

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -1,0 +1,17 @@
+# Tests
+
+`test` blocks execute SQL to verify that generated resources behave as expected. Each test can define optional `setup` and `teardown` statements, `assert` queries that must succeed, and `assert_fail` queries that should fail.
+
+```hcl
+test "users_table" {
+  setup = ["INSERT INTO public.users(email) VALUES ('a@b.com')"]
+  assert = [
+    "SELECT COUNT(*) = 1 FROM public.users"
+  ]
+  assert_fail = [
+    "INSERT INTO public.users(email) VALUES ('a@b.com')"
+  ]
+}
+```
+
+When run against Postgres, each test executes inside a transaction and rolls back automatically. The PGlite backend runs tests in-memory for fast feedback.

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -1,0 +1,60 @@
+# Variables and Repetition
+
+Variables let you parameterize your schemas. Declare them with a `variable` block and reference using `var.<name>`.
+
+```hcl
+variable "schema" {
+  type    = "string"
+  default = "public"
+  validation {
+    condition     = var.schema != ""
+    error_message = "schema must not be empty"
+  }
+}
+```
+
+### `for_each` and `count`
+
+Blocks can be repeated dynamically using `for_each` over a list or object, or a numeric `count`:
+
+```hcl
+trigger "upd" {
+  for_each = var.tables
+  name     = "set_updated_at_${each.value}"
+  table    = each.value
+  timing   = "BEFORE"
+  events   = ["UPDATE"]
+  level    = "ROW"
+  function = "set_updated_at"
+}
+
+trigger "rep" {
+  count = 2
+  name  = "rep_${count.index}"
+  ...
+}
+```
+
+### Dynamic blocks
+
+`dynamic` blocks replicate nested blocks. `each.key` and `each.value` are available inside the `content` section.
+
+```hcl
+variable "cols" {
+  default = {
+    id   = { type = "serial", nullable = false }
+    name = { type = "text",   nullable = true }
+  }
+}
+
+table "users" {
+  dynamic "column" {
+    for_each = var.cols
+    labels   = [each.key]
+    content {
+      type     = each.value.type
+      nullable = each.value.nullable
+    }
+  }
+}
+```


### PR DESCRIPTION
## Summary
- document every Postgres resource in dedicated files under `docs/postgres`
- add guides for variables, locals, modules, outputs, and tests
- trim README and link to the new documentation

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b957b745e08331a87c59640ae136ec