### PR TITLE
Support complex variable types

### DIFF
--- a/docs/variables.md
+++ b/docs/variables.md
@@ -13,6 +13,20 @@ variable "schema" {
 }
 ```
 
+### Typed variables
+
+Variables may declare complex types to ensure the provided values match expectations:
+
+```hcl
+variable "ids" {
+  type = "list(number)"
+}
+
+variable "labels" {
+  type = "map(string)"
+}
+```
+
 ### `for_each` and `count`
 
 Blocks can be repeated dynamically using `for_each` over a list or object, or a numeric `count`:


### PR DESCRIPTION
## Summary
- allow variable specs to declare complex types such as lists and maps
- validate values recursively against declared variable types
- document typed variable examples

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b9920f123883319ac3f254f408fb1e