### PR TITLE
Add support for custom aggregates

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Prisma ORM support custom migrations, so you can use this tool to generate an SQ
 - [view](docs/postgres/view.md)
 - [materialized view](docs/postgres/materialized.md)
 - [function](docs/postgres/function.md)
+- [aggregate](docs/postgres/aggregate.md)
 - [trigger](docs/postgres/trigger.md)
 - [event trigger](docs/postgres/event_trigger.md)
 - [extension](docs/postgres/extension.md)

--- a/docs/postgres/aggregate.md
+++ b/docs/postgres/aggregate.md
@@ -1,0 +1,26 @@
+# Aggregate
+
+Creates a user-defined aggregate function.
+
+```hcl
+aggregate "sum_int" {
+  schema  = "public"
+  inputs  = ["int"]
+  sfunc   = "int_sum"
+  stype   = "int"
+  finalfunc = "int4_sum_final"
+  initcond  = "0"
+  parallel  = "safe"
+}
+```
+
+## Attributes
+- `name` (label): aggregate name.
+- `schema` (string, optional): schema for the aggregate. Defaults to `public`.
+- `inputs` (list of strings, optional): argument data types.
+- `sfunc` (string): state transition function.
+- `stype` (string): state data type.
+- `finalfunc` (string, optional): final function.
+- `initcond` (string, optional): initial state value.
+- `parallel` (string, optional): `safe`, `restricted`, or `unsafe`.
+- `comment` (string, optional): documentation comment.

--- a/src/backends/postgres.rs
+++ b/src/backends/postgres.rs
@@ -215,6 +215,22 @@ fn to_sql(cfg: &Config) -> Result<String> {
         }
     }
 
+    for a in &cfg.aggregates {
+        out.push_str(&format!("{}\n\n", pg::Aggregate::from(a)));
+        if let Some(comment) = &a.comment {
+            let schema = a.schema.clone().unwrap_or_else(|| "public".to_string());
+            let name = a.alt_name.clone().unwrap_or_else(|| a.name.clone());
+            let inputs = a.inputs.join(", ");
+            out.push_str(&format!(
+                "COMMENT ON AGGREGATE {}.{}({}) IS {};\n\n",
+                pg::ident(&schema),
+                pg::ident(&name),
+                inputs,
+                pg::literal(comment)
+            ));
+        }
+    }
+
     for v in &cfg.views {
         out.push_str(&format!("{}\n\n", pg::View::from(v)));
         if let Some(comment) = &v.comment {

--- a/src/config.rs
+++ b/src/config.rs
@@ -84,6 +84,7 @@ pub enum ResourceKind {
     Tables,
     Views,
     Materialized,
+    Aggregates,
     Functions,
     Triggers,
     EventTriggers,
@@ -105,6 +106,7 @@ impl fmt::Display for ResourceKind {
             ResourceKind::Tables => "tables",
             ResourceKind::Views => "views",
             ResourceKind::Materialized => "materialized",
+            ResourceKind::Aggregates => "aggregates",
             ResourceKind::Functions => "functions",
             ResourceKind::Triggers => "triggers",
             ResourceKind::EventTriggers => "event_triggers",
@@ -131,6 +133,7 @@ impl std::str::FromStr for ResourceKind {
             "tables" => Ok(ResourceKind::Tables),
             "views" => Ok(ResourceKind::Views),
             "materialized" => Ok(ResourceKind::Materialized),
+            "aggregates" => Ok(ResourceKind::Aggregates),
             "functions" => Ok(ResourceKind::Functions),
             "triggers" => Ok(ResourceKind::Triggers),
             "event_triggers" => Ok(ResourceKind::EventTriggers),
@@ -158,6 +161,7 @@ impl TargetConfig {
                 ResourceKind::Tables,
                 ResourceKind::Views,
                 ResourceKind::Materialized,
+                ResourceKind::Aggregates,
                 ResourceKind::Functions,
                 ResourceKind::Triggers,
                 ResourceKind::EventTriggers,
@@ -232,7 +236,8 @@ mod tests {
         assert!(include_set.contains(&ResourceKind::Tables));
         assert!(include_set.contains(&ResourceKind::Enums));
         assert!(include_set.contains(&ResourceKind::EventTriggers));
-        assert_eq!(include_set.len(), 16); // All resource types
+        assert!(include_set.contains(&ResourceKind::Aggregates));
+        assert_eq!(include_set.len(), 17); // All resource types
     }
 
     #[test]

--- a/src/frontend/ast/mod.rs
+++ b/src/frontend/ast/mod.rs
@@ -3,6 +3,7 @@ use hcl::{Expression, Value};
 #[derive(Debug, Clone, Default)]
 pub struct Config {
     pub functions: Vec<AstFunction>,
+    pub aggregates: Vec<AstAggregate>,
     pub triggers: Vec<AstTrigger>,
     pub event_triggers: Vec<AstEventTrigger>,
     pub extensions: Vec<AstExtension>,
@@ -36,6 +37,20 @@ pub struct AstFunction {
     pub security: Option<String>,
     pub cost: Option<f64>,
     pub body: String,
+    pub comment: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AstAggregate {
+    pub name: String,
+    pub alt_name: Option<String>,
+    pub schema: Option<String>,
+    pub inputs: Vec<String>,
+    pub sfunc: String,
+    pub stype: String,
+    pub finalfunc: Option<String>,
+    pub initcond: Option<String>,
+    pub parallel: Option<String>,
     pub comment: Option<String>,
 }
 

--- a/src/frontend/core.rs
+++ b/src/frontend/core.rs
@@ -1113,6 +1113,25 @@ fn load_file(
         )?;
     }
 
+    for blk in body.blocks().filter(|b| b.identifier() == "aggregate") {
+        let name = blk
+            .labels()
+            .get(0)
+            .ok_or_else(|| anyhow::anyhow!("aggregate block missing name label"))?
+            .as_str()
+            .to_string();
+        let for_each_expr = find_attr(blk.body(), "for_each");
+        let count_expr = find_attr(blk.body(), "count");
+        execute_for_each::<ast::AstAggregate>(
+            &name,
+            blk.body(),
+            &env,
+            &mut cfg,
+            for_each_expr,
+            count_expr,
+        )?;
+    }
+
     for blk in body.blocks().filter(|b| b.identifier() == "trigger") {
         let name = blk
             .labels()

--- a/src/frontend/lower.rs
+++ b/src/frontend/lower.rs
@@ -4,6 +4,7 @@ use crate::ir;
 pub fn lower_config(ast: ast::Config) -> ir::Config {
     ir::Config {
         functions: ast.functions.into_iter().map(Into::into).collect(),
+        aggregates: ast.aggregates.into_iter().map(Into::into).collect(),
         triggers: ast.triggers.into_iter().map(Into::into).collect(),
         event_triggers: ast.event_triggers.into_iter().map(Into::into).collect(),
         extensions: ast.extensions.into_iter().map(Into::into).collect(),
@@ -40,6 +41,23 @@ impl From<ast::AstFunction> for ir::FunctionSpec {
             cost: f.cost,
             body: f.body,
             comment: f.comment,
+        }
+    }
+}
+
+impl From<ast::AstAggregate> for ir::AggregateSpec {
+    fn from(a: ast::AstAggregate) -> Self {
+        Self {
+            name: a.name,
+            alt_name: a.alt_name,
+            schema: a.schema,
+            inputs: a.inputs,
+            sfunc: a.sfunc,
+            stype: a.stype,
+            finalfunc: a.finalfunc,
+            initcond: a.initcond,
+            parallel: a.parallel,
+            comment: a.comment,
         }
     }
 }

--- a/src/frontend/resource_impls.rs
+++ b/src/frontend/resource_impls.rs
@@ -378,6 +378,44 @@ impl ForEachSupport for AstFunction {
     }
 }
 
+// Aggregate implementation
+impl ForEachSupport for AstAggregate {
+    type Item = Self;
+
+    fn parse_one(name: &str, body: &Body, env: &EnvVars) -> Result<Self::Item> {
+        let alt_name = get_attr_string(body, "name", env)?;
+        let schema = get_attr_string(body, "schema", env)?;
+        let inputs = match find_attr(body, "inputs") {
+            Some(attr) => expr_to_string_vec(attr.expr(), env)?,
+            None => Vec::new(),
+        };
+        let sfunc = get_attr_string(body, "sfunc", env)?
+            .context("aggregate 'sfunc' is required")?;
+        let stype = get_attr_string(body, "stype", env)?
+            .context("aggregate 'stype' is required")?;
+        let finalfunc = get_attr_string(body, "finalfunc", env)?;
+        let initcond = get_attr_string(body, "initcond", env)?;
+        let parallel = get_attr_string(body, "parallel", env)?;
+        let comment = get_attr_string(body, "comment", env)?;
+        Ok(AstAggregate {
+            name: name.to_string(),
+            alt_name,
+            schema,
+            inputs,
+            sfunc,
+            stype,
+            finalfunc,
+            initcond,
+            parallel,
+            comment,
+        })
+    }
+
+    fn add_to_config(item: Self::Item, config: &mut Config) {
+        config.aggregates.push(item);
+    }
+}
+
 // Trigger implementation
 impl ForEachSupport for AstTrigger {
     type Item = Self;

--- a/src/ir/config.rs
+++ b/src/ir/config.rs
@@ -4,6 +4,7 @@ use serde::Serialize;
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct Config {
     pub functions: Vec<FunctionSpec>,
+    pub aggregates: Vec<AggregateSpec>,
     pub triggers: Vec<TriggerSpec>,
     pub event_triggers: Vec<EventTriggerSpec>,
     pub extensions: Vec<ExtensionSpec>,
@@ -37,6 +38,20 @@ pub struct FunctionSpec {
     pub security: Option<String>,
     pub cost: Option<f64>,
     pub body: String,
+    pub comment: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AggregateSpec {
+    pub name: String,
+    pub alt_name: Option<String>,
+    pub schema: Option<String>,
+    pub inputs: Vec<String>,
+    pub sfunc: String,
+    pub stype: String,
+    pub finalfunc: Option<String>,
+    pub initcond: Option<String>,
+    pub parallel: Option<String>,
     pub comment: Option<String>,
 }
 

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -2,7 +2,8 @@ pub mod config;
 
 pub use config::{
     BackReferenceSpec, CheckSpec, ColumnSpec, CompositeTypeFieldSpec, CompositeTypeSpec, Config,
-    DomainSpec, EnumSpec, EventTriggerSpec, ExtensionSpec, ForeignKeySpec, FunctionSpec, GrantSpec,
-    IndexSpec, MaterializedViewSpec, OutputSpec, PolicySpec, PrimaryKeySpec, RoleSpec, SchemaSpec,
-    SequenceSpec, StandaloneIndexSpec, TableSpec, TestSpec, TriggerSpec, ViewSpec,
+    DomainSpec, EnumSpec, EventTriggerSpec, ExtensionSpec, ForeignKeySpec, FunctionSpec,
+    AggregateSpec, GrantSpec, IndexSpec, MaterializedViewSpec, OutputSpec, PolicySpec,
+    PrimaryKeySpec, RoleSpec, SchemaSpec, SequenceSpec, StandaloneIndexSpec, TableSpec, TestSpec,
+    TriggerSpec, ViewSpec,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,9 +19,9 @@ use std::path::Path;
 // Public re-exports
 use crate::frontend::env::EnvVars;
 pub use ir::{
-    CompositeTypeSpec, Config, DomainSpec, EnumSpec, EventTriggerSpec, ExtensionSpec, FunctionSpec,
-    GrantSpec, MaterializedViewSpec, OutputSpec, PolicySpec, RoleSpec, SchemaSpec, SequenceSpec,
-    TableSpec, TriggerSpec, ViewSpec,
+    AggregateSpec, CompositeTypeSpec, Config, DomainSpec, EnumSpec, EventTriggerSpec, ExtensionSpec,
+    FunctionSpec, GrantSpec, MaterializedViewSpec, OutputSpec, PolicySpec, RoleSpec, SchemaSpec,
+    SequenceSpec, TableSpec, TriggerSpec, ViewSpec,
 };
 
 // Loader abstraction: lets callers control how files are read.
@@ -55,6 +55,7 @@ where
 
     Config {
         functions: maybe!(Functions, functions),
+        aggregates: maybe!(Aggregates, aggregates),
         triggers: maybe!(Triggers, triggers),
         event_triggers: maybe!(EventTriggers, event_triggers),
         extensions: maybe!(Extensions, extensions),


### PR DESCRIPTION
## Summary
- add `AggregateSpec` and AST parsing for `aggregate` blocks
- generate `CREATE AGGREGATE` SQL
- document aggregate support and link from README

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b9c6cc1be08331b4a78a1add8df4c6