### PR TITLE
Add collation support for Postgres

### DIFF
--- a/docs/Readme.md
+++ b/docs/Readme.md
@@ -31,6 +31,7 @@ We aim to support all major PostgreSQL features. See the reference docs:
 - [Trigger](postgres/trigger.md)
 - [Event Trigger](postgres/event_trigger.md)
 - [Extension](postgres/extension.md)
+- [Collation](postgres/collation.md)
 - [Policy](postgres/policy.md)
 - [Role](postgres/role.md)
 - [Grant](postgres/grant.md)

--- a/docs/postgres/collation.md
+++ b/docs/postgres/collation.md
@@ -1,0 +1,24 @@
+# Collation
+
+Defines a text collation used for locale-aware sorting.
+
+```hcl
+collation "en_us" {
+  schema = "public"
+  locale = "en_US"
+  provider = "icu"
+}
+```
+
+## Attributes
+- `name` (label): collation name.
+- `schema` (string, optional): schema for the collation. Defaults to `public`.
+- `if_not_exists` (bool, optional): emit `IF NOT EXISTS`.
+- `from` (string, optional): copy from an existing collation.
+- `locale` (string, optional): sets `LOCALE`.
+- `lc_collate` (string, optional): sets `LC_COLLATE`.
+- `lc_ctype` (string, optional): sets `LC_CTYPE`.
+- `provider` (string, optional): provider such as `icu` or `libc`.
+- `deterministic` (bool, optional): emit `DETERMINISTIC = true|false`.
+- `version` (string, optional): sets `VERSION`.
+- `comment` (string, optional): documentation comment.

--- a/src/backends/postgres.rs
+++ b/src/backends/postgres.rs
@@ -56,6 +56,20 @@ fn to_sql(cfg: &Config) -> Result<String> {
         }
     }
 
+    for c in &cfg.collations {
+        out.push_str(&format!("{}\n\n", pg::Collation::from(c)));
+        if let Some(comment) = &c.comment {
+            let schema = c.schema.clone().unwrap_or_else(|| "public".to_string());
+            let name = c.alt_name.clone().unwrap_or_else(|| c.name.clone());
+            out.push_str(&format!(
+                "COMMENT ON COLLATION {}.{} IS {};\n\n",
+                pg::ident(&schema),
+                pg::ident(&name),
+                pg::literal(comment)
+            ));
+        }
+    }
+
     for s in &cfg.sequences {
         out.push_str(&format!("{}\n\n", pg::Sequence::from(s)));
         if let Some(comment) = &s.comment {

--- a/src/config.rs
+++ b/src/config.rs
@@ -89,6 +89,7 @@ pub enum ResourceKind {
     Triggers,
     EventTriggers,
     Extensions,
+    Collations,
     Sequences,
     Policies,
     Roles,
@@ -111,6 +112,7 @@ impl fmt::Display for ResourceKind {
             ResourceKind::Triggers => "triggers",
             ResourceKind::EventTriggers => "event_triggers",
             ResourceKind::Extensions => "extensions",
+            ResourceKind::Collations => "collations",
             ResourceKind::Sequences => "sequences",
             ResourceKind::Policies => "policies",
             ResourceKind::Roles => "roles",
@@ -138,6 +140,7 @@ impl std::str::FromStr for ResourceKind {
             "triggers" => Ok(ResourceKind::Triggers),
             "event_triggers" => Ok(ResourceKind::EventTriggers),
             "extensions" => Ok(ResourceKind::Extensions),
+            "collations" => Ok(ResourceKind::Collations),
             "sequences" => Ok(ResourceKind::Sequences),
             "policies" => Ok(ResourceKind::Policies),
             "roles" => Ok(ResourceKind::Roles),
@@ -166,6 +169,7 @@ impl TargetConfig {
                 ResourceKind::Triggers,
                 ResourceKind::EventTriggers,
                 ResourceKind::Extensions,
+                ResourceKind::Collations,
                 ResourceKind::Sequences,
                 ResourceKind::Policies,
                 ResourceKind::Roles,
@@ -237,7 +241,8 @@ mod tests {
         assert!(include_set.contains(&ResourceKind::Enums));
         assert!(include_set.contains(&ResourceKind::EventTriggers));
         assert!(include_set.contains(&ResourceKind::Aggregates));
-        assert_eq!(include_set.len(), 17); // All resource types
+        assert!(include_set.contains(&ResourceKind::Collations));
+        assert_eq!(include_set.len(), 18); // All resource types
     }
 
     #[test]

--- a/src/frontend/ast/mod.rs
+++ b/src/frontend/ast/mod.rs
@@ -7,6 +7,7 @@ pub struct Config {
     pub triggers: Vec<AstTrigger>,
     pub event_triggers: Vec<AstEventTrigger>,
     pub extensions: Vec<AstExtension>,
+    pub collations: Vec<AstCollation>,
     pub sequences: Vec<AstSequence>,
     pub schemas: Vec<AstSchema>,
     pub enums: Vec<AstEnum>,
@@ -86,6 +87,22 @@ pub struct AstExtension {
     pub alt_name: Option<String>,
     pub if_not_exists: bool,
     pub schema: Option<String>,
+    pub version: Option<String>,
+    pub comment: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AstCollation {
+    pub name: String,
+    pub alt_name: Option<String>,
+    pub schema: Option<String>,
+    pub if_not_exists: bool,
+    pub from: Option<String>,
+    pub locale: Option<String>,
+    pub lc_collate: Option<String>,
+    pub lc_ctype: Option<String>,
+    pub provider: Option<String>,
+    pub deterministic: Option<bool>,
     pub version: Option<String>,
     pub comment: Option<String>,
 }

--- a/src/frontend/core.rs
+++ b/src/frontend/core.rs
@@ -1230,6 +1230,25 @@ fn load_file(
         )?;
     }
 
+    for blk in body.blocks().filter(|b| b.identifier() == "collation") {
+        let name = blk
+            .labels()
+            .get(0)
+            .ok_or_else(|| anyhow::anyhow!("collation block missing name label"))?
+            .as_str()
+            .to_string();
+        let for_each_expr = find_attr(blk.body(), "for_each");
+        let count_expr = find_attr(blk.body(), "count");
+        execute_for_each::<ast::AstCollation>(
+            &name,
+            blk.body(),
+            &env,
+            &mut cfg,
+            for_each_expr,
+            count_expr,
+        )?;
+    }
+
     for blk in body.blocks().filter(|b| b.identifier() == "enum") {
         let name = blk
             .labels()

--- a/src/frontend/lower.rs
+++ b/src/frontend/lower.rs
@@ -8,6 +8,7 @@ pub fn lower_config(ast: ast::Config) -> ir::Config {
         triggers: ast.triggers.into_iter().map(Into::into).collect(),
         event_triggers: ast.event_triggers.into_iter().map(Into::into).collect(),
         extensions: ast.extensions.into_iter().map(Into::into).collect(),
+        collations: ast.collations.into_iter().map(Into::into).collect(),
         sequences: ast.sequences.into_iter().map(Into::into).collect(),
         schemas: ast.schemas.into_iter().map(Into::into).collect(),
         enums: ast.enums.into_iter().map(Into::into).collect(),
@@ -105,6 +106,25 @@ impl From<ast::AstExtension> for ir::ExtensionSpec {
             schema: e.schema,
             version: e.version,
             comment: e.comment,
+        }
+    }
+}
+
+impl From<ast::AstCollation> for ir::CollationSpec {
+    fn from(c: ast::AstCollation) -> Self {
+        Self {
+            name: c.name,
+            alt_name: c.alt_name,
+            schema: c.schema,
+            if_not_exists: c.if_not_exists,
+            from: c.from,
+            locale: c.locale,
+            lc_collate: c.lc_collate,
+            lc_ctype: c.lc_ctype,
+            provider: c.provider,
+            deterministic: c.deterministic,
+            version: c.version,
+            comment: c.comment,
         }
     }
 }

--- a/src/frontend/resource_impls.rs
+++ b/src/frontend/resource_impls.rs
@@ -583,6 +583,43 @@ impl ForEachSupport for AstExtension {
     }
 }
 
+// Collation implementation
+impl ForEachSupport for AstCollation {
+    type Item = Self;
+
+    fn parse_one(name: &str, body: &Body, env: &EnvVars) -> Result<Self::Item> {
+        let alt_name = get_attr_string(body, "name", env)?;
+        let schema = get_attr_string(body, "schema", env)?;
+        let if_not_exists = get_attr_bool(body, "if_not_exists", env)?.unwrap_or(true);
+        let from = get_attr_string(body, "from", env)?;
+        let locale = get_attr_string(body, "locale", env)?;
+        let lc_collate = get_attr_string(body, "lc_collate", env)?;
+        let lc_ctype = get_attr_string(body, "lc_ctype", env)?;
+        let provider = get_attr_string(body, "provider", env)?;
+        let deterministic = get_attr_bool(body, "deterministic", env)?;
+        let version = get_attr_string(body, "version", env)?;
+        let comment = get_attr_string(body, "comment", env)?;
+        Ok(AstCollation {
+            name: name.to_string(),
+            alt_name,
+            schema,
+            if_not_exists,
+            from,
+            locale,
+            lc_collate,
+            lc_ctype,
+            provider,
+            deterministic,
+            version,
+            comment,
+        })
+    }
+
+    fn add_to_config(item: Self::Item, config: &mut Config) {
+        config.collations.push(item);
+    }
+}
+
 // Enum implementation
 impl ForEachSupport for AstEnum {
     type Item = Self;

--- a/src/ir/config.rs
+++ b/src/ir/config.rs
@@ -8,6 +8,7 @@ pub struct Config {
     pub triggers: Vec<TriggerSpec>,
     pub event_triggers: Vec<EventTriggerSpec>,
     pub extensions: Vec<ExtensionSpec>,
+    pub collations: Vec<CollationSpec>,
     pub sequences: Vec<SequenceSpec>,
     pub schemas: Vec<SchemaSpec>,
     pub enums: Vec<EnumSpec>,
@@ -89,6 +90,22 @@ pub struct ExtensionSpec {
     pub alt_name: Option<String>,
     pub if_not_exists: bool,
     pub schema: Option<String>,
+    pub version: Option<String>,
+    pub comment: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CollationSpec {
+    pub name: String,
+    pub alt_name: Option<String>,
+    pub schema: Option<String>,
+    pub if_not_exists: bool,
+    pub from: Option<String>,
+    pub locale: Option<String>,
+    pub lc_collate: Option<String>,
+    pub lc_ctype: Option<String>,
+    pub provider: Option<String>,
+    pub deterministic: Option<bool>,
     pub version: Option<String>,
     pub comment: Option<String>,
 }

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -3,6 +3,7 @@ pub mod config;
 pub use config::{
     AggregateSpec, BackReferenceSpec, CheckSpec, ColumnSpec, CompositeTypeFieldSpec,
     CompositeTypeSpec, Config, DomainSpec, EnumSpec, EventTriggerSpec, ExtensionSpec,
+    CollationSpec,
     ForeignKeySpec, FunctionSpec, GrantSpec, IndexSpec, MaterializedViewSpec, OutputSpec,
     PartitionBySpec, PartitionSpec, PolicySpec, PrimaryKeySpec, PublicationSpec,
     PublicationTableSpec, RoleSpec, SchemaSpec, SequenceSpec, StandaloneIndexSpec,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ use std::path::Path;
 // Public re-exports
 use crate::frontend::env::EnvVars;
 pub use ir::{
-    AggregateSpec, CompositeTypeSpec, Config, DomainSpec, EnumSpec, EventTriggerSpec,
+    AggregateSpec, CollationSpec, CompositeTypeSpec, Config, DomainSpec, EnumSpec, EventTriggerSpec,
     ExtensionSpec, FunctionSpec, GrantSpec, MaterializedViewSpec, OutputSpec, PolicySpec, RoleSpec,
     SchemaSpec, SequenceSpec, TableSpec, TriggerSpec, ViewSpec,
 };
@@ -59,6 +59,7 @@ where
         triggers: maybe!(Triggers, triggers),
         event_triggers: maybe!(EventTriggers, event_triggers),
         extensions: maybe!(Extensions, extensions),
+        collations: maybe!(Collations, collations),
         sequences: maybe!(Sequences, sequences),
         schemas: maybe!(Schemas, schemas),
         enums: maybe!(Enums, enums),

--- a/src/main.rs
+++ b/src/main.rs
@@ -695,6 +695,7 @@ fn cli_filter_sets(
             R::Functions,
             R::Triggers,
             R::Extensions,
+            R::Collations,
             R::Sequences,
             R::Policies,
             R::Tests,

--- a/src/postgres/collation.rs
+++ b/src/postgres/collation.rs
@@ -1,0 +1,99 @@
+use std::fmt;
+
+use crate::postgres::{ident, literal};
+
+#[derive(Debug, Clone)]
+pub struct Collation {
+    pub schema: String,
+    pub name: String,
+    pub if_not_exists: bool,
+    pub from: Option<String>,
+    pub locale: Option<String>,
+    pub lc_collate: Option<String>,
+    pub lc_ctype: Option<String>,
+    pub provider: Option<String>,
+    pub deterministic: Option<bool>,
+    pub version: Option<String>,
+}
+
+impl From<&crate::ir::CollationSpec> for Collation {
+    fn from(c: &crate::ir::CollationSpec) -> Self {
+        Self {
+            schema: c.schema.clone().unwrap_or_else(|| "public".to_string()),
+            name: c.alt_name.clone().unwrap_or_else(|| c.name.clone()),
+            if_not_exists: c.if_not_exists,
+            from: c.from.clone(),
+            locale: c.locale.clone(),
+            lc_collate: c.lc_collate.clone(),
+            lc_ctype: c.lc_ctype.clone(),
+            provider: c.provider.clone(),
+            deterministic: c.deterministic,
+            version: c.version.clone(),
+        }
+    }
+}
+
+impl fmt::Display for Collation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "CREATE COLLATION")?;
+        if self.if_not_exists {
+            write!(f, " IF NOT EXISTS")?;
+        }
+        write!(f, " {}.{}", ident(&self.schema), ident(&self.name))?;
+        if let Some(from) = &self.from {
+            write!(f, " FROM {from}")?;
+        } else {
+            let mut parts = Vec::new();
+            if let Some(locale) = &self.locale {
+                parts.push(format!("LOCALE = {}", literal(locale)));
+            }
+            if let Some(lc_collate) = &self.lc_collate {
+                parts.push(format!("LC_COLLATE = {}", literal(lc_collate)));
+            }
+            if let Some(lc_ctype) = &self.lc_ctype {
+                parts.push(format!("LC_CTYPE = {}", literal(lc_ctype)));
+            }
+            if let Some(provider) = &self.provider {
+                parts.push(format!("PROVIDER = {}", provider.to_uppercase()));
+            }
+            if let Some(det) = self.deterministic {
+                parts.push(format!("DETERMINISTIC = {}", if det { "true" } else { "false" }));
+            }
+            if let Some(version) = &self.version {
+                parts.push(format!("VERSION = {}", literal(version)));
+            }
+            if !parts.is_empty() {
+                write!(f, " ({})", parts.join(", "))?;
+            }
+        }
+        write!(f, ";")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn collation_with_locale() {
+        let spec = crate::ir::CollationSpec {
+            name: "c".into(),
+            alt_name: None,
+            schema: None,
+            if_not_exists: true,
+            from: None,
+            locale: Some("en_US".into()),
+            lc_collate: None,
+            lc_ctype: None,
+            provider: None,
+            deterministic: None,
+            version: None,
+            comment: None,
+        };
+        let coll = Collation::from(&spec);
+        assert_eq!(
+            coll.to_string(),
+            "CREATE COLLATION IF NOT EXISTS \"public\".\"c\" (LOCALE = 'en_US');"
+        );
+    }
+}

--- a/src/postgres/mod.rs
+++ b/src/postgres/mod.rs
@@ -1,4 +1,8 @@
+pub mod collation;
+
 use std::fmt;
+
+pub use collation::Collation;
 
 pub fn ident(s: &str) -> String {
     let escaped = s.replace('"', "\"");


### PR DESCRIPTION
## Summary
- add IR and frontend support for `collation` resources
- generate `CREATE COLLATION` statements for Postgres
- document collation usage and link from overview

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68c462ca15bc8331b00b9ea4eb843263