### PR TITLE
Add text search resources

### DIFF
--- a/docs/Readme.md
+++ b/docs/Readme.md
@@ -40,3 +40,7 @@ We aim to support all major PostgreSQL features. See the reference docs:
 - [Foreign Data Wrapper](postgres/foreign_data_wrapper.md)
 - [Foreign Server](postgres/foreign_server.md)
 - [Foreign Table](postgres/foreign_table.md)
+- [Text Search Dictionary](postgres/text_search_dictionary.md)
+- [Text Search Configuration](postgres/text_search_configuration.md)
+- [Text Search Template](postgres/text_search_template.md)
+- [Text Search Parser](postgres/text_search_parser.md)

--- a/docs/postgres/text_search_configuration.md
+++ b/docs/postgres/text_search_configuration.md
@@ -1,0 +1,31 @@
+# Text Search Configuration
+
+Defines a full text search configuration and optional mappings.
+
+```hcl
+text_search_configuration "english" {
+  parser = "default"
+
+  mapping {
+    for  = ["asciiword"]
+    with = ["english_stem"]
+  }
+}
+```
+
+## Attributes
+- `name` (label): configuration name.
+- `schema` (string, optional): schema of the configuration.
+- `parser` (string): text search parser.
+- `mapping` (block, multiple, optional): add mappings. Each block requires:
+  - `for` (array of strings): token types.
+  - `with` (array of strings): dictionaries to use.
+- `comment` (string, optional): documentation comment.
+
+## Examples
+
+```hcl
+text_search_configuration "simple_config" {
+  parser = "default"
+}
+```

--- a/docs/postgres/text_search_dictionary.md
+++ b/docs/postgres/text_search_dictionary.md
@@ -1,0 +1,26 @@
+# Text Search Dictionary
+
+Defines a full text search dictionary.
+
+```hcl
+text_search_dictionary "english" {
+  schema   = "public"
+  template = "simple"
+  options  = ["dictfile = 'english'"]
+}
+```
+
+## Attributes
+- `name` (label): dictionary name.
+- `schema` (string, optional): schema of the dictionary.
+- `template` (string): template to use.
+- `options` (array of strings, optional): additional `OPTION` entries.
+- `comment` (string, optional): documentation comment.
+
+## Examples
+
+```hcl
+text_search_dictionary "simple_dict" {
+  template = "simple"
+}
+```

--- a/docs/postgres/text_search_parser.md
+++ b/docs/postgres/text_search_parser.md
@@ -1,0 +1,34 @@
+# Text Search Parser
+
+Defines a full text search parser.
+
+```hcl
+text_search_parser "my_parser" {
+  start    = "ts_parse_start"
+  gettoken = "ts_parse_gettoken"
+  end      = "ts_parse_end"
+  lextypes = "ts_parse_lextypes"
+  headline = "ts_parse_headline"
+}
+```
+
+## Attributes
+- `name` (label): parser name.
+- `schema` (string, optional): schema of the parser.
+- `start` (string): start function.
+- `gettoken` (string): gettoken function.
+- `end` (string): end function.
+- `lextypes` (string): lextypes function.
+- `headline` (string, optional): headline function.
+- `comment` (string, optional): documentation comment.
+
+## Examples
+
+```hcl
+text_search_parser "simple_parser" {
+  start    = "ts_parse_start"
+  gettoken = "ts_parse_gettoken"
+  end      = "ts_parse_end"
+  lextypes = "ts_parse_lextypes"
+}
+```

--- a/docs/postgres/text_search_template.md
+++ b/docs/postgres/text_search_template.md
@@ -1,0 +1,25 @@
+# Text Search Template
+
+Defines a full text search template.
+
+```hcl
+text_search_template "my_template" {
+  lexize = "simple_lexize"
+  init   = "simple_init"
+}
+```
+
+## Attributes
+- `name` (label): template name.
+- `schema` (string, optional): schema of the template.
+- `lexize` (string): lexize function.
+- `init` (string, optional): init function.
+- `comment` (string, optional): documentation comment.
+
+## Examples
+
+```hcl
+text_search_template "simple_template" {
+  lexize = "simple_lexize"
+}
+```

--- a/src/backends/postgres.rs
+++ b/src/backends/postgres.rs
@@ -70,6 +70,62 @@ fn to_sql(cfg: &Config) -> Result<String> {
         }
     }
 
+    for d in &cfg.text_search_dictionaries {
+        out.push_str(&format!("{}\n\n", pg::TextSearchDictionary::from(d)));
+        if let Some(comment) = &d.comment {
+            let schema = d.schema.clone().unwrap_or_else(|| "public".to_string());
+            let name = d.alt_name.clone().unwrap_or_else(|| d.name.clone());
+            out.push_str(&format!(
+                "COMMENT ON TEXT SEARCH DICTIONARY {}.{} IS {};\n\n",
+                pg::ident(&schema),
+                pg::ident(&name),
+                pg::literal(comment)
+            ));
+        }
+    }
+
+    for t in &cfg.text_search_templates {
+        out.push_str(&format!("{}\n\n", pg::TextSearchTemplate::from(t)));
+        if let Some(comment) = &t.comment {
+            let schema = t.schema.clone().unwrap_or_else(|| "public".to_string());
+            let name = t.alt_name.clone().unwrap_or_else(|| t.name.clone());
+            out.push_str(&format!(
+                "COMMENT ON TEXT SEARCH TEMPLATE {}.{} IS {};\n\n",
+                pg::ident(&schema),
+                pg::ident(&name),
+                pg::literal(comment)
+            ));
+        }
+    }
+
+    for p in &cfg.text_search_parsers {
+        out.push_str(&format!("{}\n\n", pg::TextSearchParser::from(p)));
+        if let Some(comment) = &p.comment {
+            let schema = p.schema.clone().unwrap_or_else(|| "public".to_string());
+            let name = p.alt_name.clone().unwrap_or_else(|| p.name.clone());
+            out.push_str(&format!(
+                "COMMENT ON TEXT SEARCH PARSER {}.{} IS {};\n\n",
+                pg::ident(&schema),
+                pg::ident(&name),
+                pg::literal(comment)
+            ));
+        }
+    }
+
+    for c in &cfg.text_search_configurations {
+        out.push_str(&format!("{}\n\n", pg::TextSearchConfiguration::from(c)));
+        if let Some(comment) = &c.comment {
+            let schema = c.schema.clone().unwrap_or_else(|| "public".to_string());
+            let name = c.alt_name.clone().unwrap_or_else(|| c.name.clone());
+            out.push_str(&format!(
+                "COMMENT ON TEXT SEARCH CONFIGURATION {}.{} IS {};\n\n",
+                pg::ident(&schema),
+                pg::ident(&name),
+                pg::literal(comment)
+            ));
+        }
+    }
+
     for s in &cfg.sequences {
         out.push_str(&format!("{}\n\n", pg::Sequence::from(s)));
         if let Some(comment) = &s.comment {

--- a/src/frontend/ast/mod.rs
+++ b/src/frontend/ast/mod.rs
@@ -23,6 +23,10 @@ pub struct Config {
     pub foreign_data_wrappers: Vec<AstForeignDataWrapper>,
     pub foreign_servers: Vec<AstForeignServer>,
     pub foreign_tables: Vec<AstForeignTable>,
+    pub text_search_dictionaries: Vec<AstTextSearchDictionary>,
+    pub text_search_configurations: Vec<AstTextSearchConfiguration>,
+    pub text_search_templates: Vec<AstTextSearchTemplate>,
+    pub text_search_parsers: Vec<AstTextSearchParser>,
     pub tests: Vec<AstTest>,
     pub outputs: Vec<AstOutput>,
 }
@@ -361,6 +365,55 @@ pub struct AstStandaloneIndex {
     pub orders: Vec<String>,
     pub operator_classes: Vec<String>,
     pub unique: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct AstTextSearchDictionary {
+    pub name: String,
+    pub alt_name: Option<String>,
+    pub schema: Option<String>,
+    pub template: String,
+    pub options: Vec<String>,
+    pub comment: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AstTextSearchConfigurationMapping {
+    pub tokens: Vec<String>,
+    pub dictionaries: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AstTextSearchConfiguration {
+    pub name: String,
+    pub alt_name: Option<String>,
+    pub schema: Option<String>,
+    pub parser: String,
+    pub mappings: Vec<AstTextSearchConfigurationMapping>,
+    pub comment: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AstTextSearchTemplate {
+    pub name: String,
+    pub alt_name: Option<String>,
+    pub schema: Option<String>,
+    pub init: Option<String>,
+    pub lexize: String,
+    pub comment: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AstTextSearchParser {
+    pub name: String,
+    pub alt_name: Option<String>,
+    pub schema: Option<String>,
+    pub start: String,
+    pub gettoken: String,
+    pub end: String,
+    pub headline: Option<String>,
+    pub lextypes: String,
+    pub comment: Option<String>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/frontend/lower.rs
+++ b/src/frontend/lower.rs
@@ -36,6 +36,26 @@ pub fn lower_config(ast: ast::Config) -> ir::Config {
             .into_iter()
             .map(Into::into)
             .collect(),
+        text_search_dictionaries: ast
+            .text_search_dictionaries
+            .into_iter()
+            .map(Into::into)
+            .collect(),
+        text_search_configurations: ast
+            .text_search_configurations
+            .into_iter()
+            .map(Into::into)
+            .collect(),
+        text_search_templates: ast
+            .text_search_templates
+            .into_iter()
+            .map(Into::into)
+            .collect(),
+        text_search_parsers: ast
+            .text_search_parsers
+            .into_iter()
+            .map(Into::into)
+            .collect(),
         publications: vec![],
         subscriptions: vec![],
         tests: ast.tests.into_iter().map(Into::into).collect(),
@@ -337,6 +357,72 @@ impl From<ast::AstForeignTable> for ir::ForeignTableSpec {
             columns: t.columns.into_iter().map(Into::into).collect(),
             options: t.options,
             comment: t.comment,
+        }
+    }
+}
+
+impl From<ast::AstTextSearchDictionary> for ir::TextSearchDictionarySpec {
+    fn from(d: ast::AstTextSearchDictionary) -> Self {
+        Self {
+            name: d.name,
+            alt_name: d.alt_name,
+            schema: d.schema,
+            template: d.template,
+            options: d.options,
+            comment: d.comment,
+        }
+    }
+}
+
+impl From<ast::AstTextSearchConfigurationMapping>
+    for ir::TextSearchConfigurationMappingSpec
+{
+    fn from(m: ast::AstTextSearchConfigurationMapping) -> Self {
+        Self {
+            tokens: m.tokens,
+            dictionaries: m.dictionaries,
+        }
+    }
+}
+
+impl From<ast::AstTextSearchConfiguration> for ir::TextSearchConfigurationSpec {
+    fn from(c: ast::AstTextSearchConfiguration) -> Self {
+        Self {
+            name: c.name,
+            alt_name: c.alt_name,
+            schema: c.schema,
+            parser: c.parser,
+            mappings: c.mappings.into_iter().map(Into::into).collect(),
+            comment: c.comment,
+        }
+    }
+}
+
+impl From<ast::AstTextSearchTemplate> for ir::TextSearchTemplateSpec {
+    fn from(t: ast::AstTextSearchTemplate) -> Self {
+        Self {
+            name: t.name,
+            alt_name: t.alt_name,
+            schema: t.schema,
+            init: t.init,
+            lexize: t.lexize,
+            comment: t.comment,
+        }
+    }
+}
+
+impl From<ast::AstTextSearchParser> for ir::TextSearchParserSpec {
+    fn from(p: ast::AstTextSearchParser) -> Self {
+        Self {
+            name: p.name,
+            alt_name: p.alt_name,
+            schema: p.schema,
+            start: p.start,
+            gettoken: p.gettoken,
+            end: p.end,
+            headline: p.headline,
+            lextypes: p.lextypes,
+            comment: p.comment,
         }
     }
 }

--- a/src/frontend/resource_impls.rs
+++ b/src/frontend/resource_impls.rs
@@ -964,3 +964,133 @@ impl ForEachSupport for AstForeignTable {
         config.foreign_tables.push(item);
     }
 }
+
+// Text Search Dictionary implementation
+impl ForEachSupport for AstTextSearchDictionary {
+    type Item = Self;
+
+    fn parse_one(name: &str, body: &Body, env: &EnvVars) -> Result<Self::Item> {
+        let alt_name = get_attr_string(body, "name", env)?;
+        let schema = get_attr_string(body, "schema", env)?;
+        let template = get_attr_string(body, "template", env)?
+            .context("text_search_dictionary 'template' is required")?;
+        let options = match find_attr(body, "options") {
+            Some(attr) => expr_to_string_vec(attr.expr(), env)?,
+            None => Vec::new(),
+        };
+        let comment = get_attr_string(body, "comment", env)?;
+        Ok(AstTextSearchDictionary {
+            name: name.to_string(),
+            alt_name,
+            schema,
+            template,
+            options,
+            comment,
+        })
+    }
+
+    fn add_to_config(item: Self::Item, config: &mut Config) {
+        config.text_search_dictionaries.push(item);
+    }
+}
+
+// Text Search Configuration implementation
+impl ForEachSupport for AstTextSearchConfiguration {
+    type Item = Self;
+
+    fn parse_one(name: &str, body: &Body, env: &EnvVars) -> Result<Self::Item> {
+        let alt_name = get_attr_string(body, "name", env)?;
+        let schema = get_attr_string(body, "schema", env)?;
+        let parser = get_attr_string(body, "parser", env)?
+            .context("text_search_configuration 'parser' is required")?;
+        let comment = get_attr_string(body, "comment", env)?;
+
+        let mut mappings = Vec::new();
+        for mblk in body.blocks().filter(|bb| bb.identifier() == "mapping") {
+            let mb = mblk.body();
+            let tokens = match find_attr(mb, "for") {
+                Some(attr) => expr_to_string_vec(attr.expr(), env)?,
+                None => bail!("mapping missing 'for' attribute"),
+            };
+            let dictionaries = match find_attr(mb, "with") {
+                Some(attr) => expr_to_string_vec(attr.expr(), env)?,
+                None => bail!("mapping missing 'with' attribute"),
+            };
+            mappings.push(AstTextSearchConfigurationMapping { tokens, dictionaries });
+        }
+
+        Ok(AstTextSearchConfiguration {
+            name: name.to_string(),
+            alt_name,
+            schema,
+            parser,
+            mappings,
+            comment,
+        })
+    }
+
+    fn add_to_config(item: Self::Item, config: &mut Config) {
+        config.text_search_configurations.push(item);
+    }
+}
+
+// Text Search Template implementation
+impl ForEachSupport for AstTextSearchTemplate {
+    type Item = Self;
+
+    fn parse_one(name: &str, body: &Body, env: &EnvVars) -> Result<Self::Item> {
+        let alt_name = get_attr_string(body, "name", env)?;
+        let schema = get_attr_string(body, "schema", env)?;
+        let lexize = get_attr_string(body, "lexize", env)?
+            .context("text_search_template 'lexize' is required")?;
+        let init = get_attr_string(body, "init", env)?;
+        let comment = get_attr_string(body, "comment", env)?;
+        Ok(AstTextSearchTemplate {
+            name: name.to_string(),
+            alt_name,
+            schema,
+            init,
+            lexize,
+            comment,
+        })
+    }
+
+    fn add_to_config(item: Self::Item, config: &mut Config) {
+        config.text_search_templates.push(item);
+    }
+}
+
+// Text Search Parser implementation
+impl ForEachSupport for AstTextSearchParser {
+    type Item = Self;
+
+    fn parse_one(name: &str, body: &Body, env: &EnvVars) -> Result<Self::Item> {
+        let alt_name = get_attr_string(body, "name", env)?;
+        let schema = get_attr_string(body, "schema", env)?;
+        let start = get_attr_string(body, "start", env)?
+            .context("text_search_parser 'start' is required")?;
+        let gettoken = get_attr_string(body, "gettoken", env)?
+            .context("text_search_parser 'gettoken' is required")?;
+        let end = get_attr_string(body, "end", env)?
+            .context("text_search_parser 'end' is required")?;
+        let headline = get_attr_string(body, "headline", env)?;
+        let lextypes = get_attr_string(body, "lextypes", env)?
+            .context("text_search_parser 'lextypes' is required")?;
+        let comment = get_attr_string(body, "comment", env)?;
+        Ok(AstTextSearchParser {
+            name: name.to_string(),
+            alt_name,
+            schema,
+            start,
+            gettoken,
+            end,
+            headline,
+            lextypes,
+            comment,
+        })
+    }
+
+    fn add_to_config(item: Self::Item, config: &mut Config) {
+        config.text_search_parsers.push(item);
+    }
+}

--- a/src/ir/config.rs
+++ b/src/ir/config.rs
@@ -24,6 +24,10 @@ pub struct Config {
     pub foreign_data_wrappers: Vec<ForeignDataWrapperSpec>,
     pub foreign_servers: Vec<ForeignServerSpec>,
     pub foreign_tables: Vec<ForeignTableSpec>,
+    pub text_search_dictionaries: Vec<TextSearchDictionarySpec>,
+    pub text_search_configurations: Vec<TextSearchConfigurationSpec>,
+    pub text_search_templates: Vec<TextSearchTemplateSpec>,
+    pub text_search_parsers: Vec<TextSearchParserSpec>,
     pub publications: Vec<PublicationSpec>,
     pub subscriptions: Vec<SubscriptionSpec>,
     pub tests: Vec<TestSpec>,
@@ -388,6 +392,55 @@ pub struct StandaloneIndexSpec {
     pub orders: Vec<String>,
     pub operator_classes: Vec<String>,
     pub unique: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TextSearchDictionarySpec {
+    pub name: String,
+    pub alt_name: Option<String>,
+    pub schema: Option<String>,
+    pub template: String,
+    pub options: Vec<String>,
+    pub comment: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TextSearchConfigurationMappingSpec {
+    pub tokens: Vec<String>,
+    pub dictionaries: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TextSearchConfigurationSpec {
+    pub name: String,
+    pub alt_name: Option<String>,
+    pub schema: Option<String>,
+    pub parser: String,
+    pub mappings: Vec<TextSearchConfigurationMappingSpec>,
+    pub comment: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TextSearchTemplateSpec {
+    pub name: String,
+    pub alt_name: Option<String>,
+    pub schema: Option<String>,
+    pub init: Option<String>,
+    pub lexize: String,
+    pub comment: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TextSearchParserSpec {
+    pub name: String,
+    pub alt_name: Option<String>,
+    pub schema: Option<String>,
+    pub start: String,
+    pub gettoken: String,
+    pub end: String,
+    pub headline: Option<String>,
+    pub lextypes: String,
+    pub comment: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -8,5 +8,7 @@ pub use config::{
     FunctionSpec, GrantSpec, IndexSpec, MaterializedViewSpec, OutputSpec,
     PartitionBySpec, PartitionSpec, PolicySpec, PrimaryKeySpec, PublicationSpec,
     PublicationTableSpec, RoleSpec, SchemaSpec, SequenceSpec, StandaloneIndexSpec,
-    SubscriptionSpec, TableSpec, TestSpec, TriggerSpec, ViewSpec,
+    SubscriptionSpec, TableSpec, TestSpec, TextSearchConfigurationMappingSpec,
+    TextSearchConfigurationSpec, TextSearchDictionarySpec, TextSearchParserSpec,
+    TextSearchTemplateSpec, TriggerSpec, ViewSpec,
 };

--- a/src/postgres/mod.rs
+++ b/src/postgres/mod.rs
@@ -2,6 +2,7 @@ pub mod collation;
 pub mod foreign_data_wrapper;
 pub mod foreign_server;
 pub mod foreign_table;
+pub mod text_search;
 
 use std::fmt;
 
@@ -9,6 +10,10 @@ pub use collation::Collation;
 pub use foreign_data_wrapper::ForeignDataWrapper;
 pub use foreign_server::ForeignServer;
 pub use foreign_table::ForeignTable;
+pub use text_search::{
+    TextSearchConfiguration, TextSearchDictionary, TextSearchParser,
+    TextSearchTemplate,
+};
 
 pub fn ident(s: &str) -> String {
     let escaped = s.replace('"', "\"");

--- a/src/postgres/text_search.rs
+++ b/src/postgres/text_search.rs
@@ -1,0 +1,187 @@
+use std::fmt;
+
+use crate::postgres::ident;
+
+#[derive(Debug, Clone)]
+pub struct TextSearchDictionary {
+    pub schema: String,
+    pub name: String,
+    pub template: String,
+    pub options: Vec<String>,
+}
+
+impl From<&crate::ir::TextSearchDictionarySpec> for TextSearchDictionary {
+    fn from(d: &crate::ir::TextSearchDictionarySpec) -> Self {
+        Self {
+            schema: d.schema.clone().unwrap_or_else(|| "public".to_string()),
+            name: d.alt_name.clone().unwrap_or_else(|| d.name.clone()),
+            template: d.template.clone(),
+            options: d.options.clone(),
+        }
+    }
+}
+
+impl fmt::Display for TextSearchDictionary {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "CREATE TEXT SEARCH DICTIONARY {}.{} (TEMPLATE = {}",
+               ident(&self.schema), ident(&self.name), self.template)?;
+        for opt in &self.options {
+            write!(f, ", {opt}")?;
+        }
+        write!(f, ");")
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TextSearchConfigurationMapping {
+    pub tokens: Vec<String>,
+    pub dictionaries: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct TextSearchConfiguration {
+    pub schema: String,
+    pub name: String,
+    pub parser: String,
+    pub mappings: Vec<TextSearchConfigurationMapping>,
+}
+
+impl From<&crate::ir::TextSearchConfigurationSpec> for TextSearchConfiguration {
+    fn from(c: &crate::ir::TextSearchConfigurationSpec) -> Self {
+        Self {
+            schema: c.schema.clone().unwrap_or_else(|| "public".to_string()),
+            name: c.alt_name.clone().unwrap_or_else(|| c.name.clone()),
+            parser: c.parser.clone(),
+            mappings: c
+                .mappings
+                .iter()
+                .map(|m| TextSearchConfigurationMapping {
+                    tokens: m.tokens.clone(),
+                    dictionaries: m.dictionaries.clone(),
+                })
+                .collect(),
+        }
+    }
+}
+
+impl fmt::Display for TextSearchConfiguration {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f,
+            "CREATE TEXT SEARCH CONFIGURATION {}.{} (PARSER = {});",
+            ident(&self.schema),
+            ident(&self.name),
+            self.parser
+        )?;
+        for m in &self.mappings {
+            write!(
+                f,
+                "\nALTER TEXT SEARCH CONFIGURATION {}.{} ADD MAPPING FOR {} WITH {};",
+                ident(&self.schema),
+                ident(&self.name),
+                m.tokens.join(", "),
+                m.dictionaries.join(", ")
+            )?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TextSearchTemplate {
+    pub schema: String,
+    pub name: String,
+    pub init: Option<String>,
+    pub lexize: String,
+}
+
+impl From<&crate::ir::TextSearchTemplateSpec> for TextSearchTemplate {
+    fn from(t: &crate::ir::TextSearchTemplateSpec) -> Self {
+        Self {
+            schema: t.schema.clone().unwrap_or_else(|| "public".to_string()),
+            name: t.alt_name.clone().unwrap_or_else(|| t.name.clone()),
+            init: t.init.clone(),
+            lexize: t.lexize.clone(),
+        }
+    }
+}
+
+impl fmt::Display for TextSearchTemplate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f,
+            "CREATE TEXT SEARCH TEMPLATE {}.{} (LEXIZE = {}",
+            ident(&self.schema),
+            ident(&self.name),
+            self.lexize
+        )?;
+        if let Some(init) = &self.init {
+            write!(f, ", INIT = {init}")?;
+        }
+        write!(f, ");")
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TextSearchParser {
+    pub schema: String,
+    pub name: String,
+    pub start: String,
+    pub gettoken: String,
+    pub end: String,
+    pub headline: Option<String>,
+    pub lextypes: String,
+}
+
+impl From<&crate::ir::TextSearchParserSpec> for TextSearchParser {
+    fn from(p: &crate::ir::TextSearchParserSpec) -> Self {
+        Self {
+            schema: p.schema.clone().unwrap_or_else(|| "public".to_string()),
+            name: p.alt_name.clone().unwrap_or_else(|| p.name.clone()),
+            start: p.start.clone(),
+            gettoken: p.gettoken.clone(),
+            end: p.end.clone(),
+            headline: p.headline.clone(),
+            lextypes: p.lextypes.clone(),
+        }
+    }
+}
+
+impl fmt::Display for TextSearchParser {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "CREATE TEXT SEARCH PARSER {}.{} (START = {}, GETTOKEN = {}, END = {}, LEXTYPES = {}",
+            ident(&self.schema),
+            ident(&self.name),
+            self.start,
+            self.gettoken,
+            self.end,
+            self.lextypes
+        )?;
+        if let Some(headline) = &self.headline {
+            write!(f, ", HEADLINE = {headline}")?;
+        }
+        write!(f, ");")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dictionary_sql_basic() {
+        let spec = crate::ir::TextSearchDictionarySpec {
+            name: "d".into(),
+            alt_name: None,
+            schema: None,
+            template: "simple".into(),
+            options: vec!["dict = 'simple'".into()],
+            comment: None,
+        };
+        let dict = TextSearchDictionary::from(&spec);
+        assert_eq!(
+            dict.to_string(),
+            "CREATE TEXT SEARCH DICTIONARY \"public\".\"d\" (TEMPLATE = simple, dict = 'simple');"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add IR, AST, and SQL support for PostgreSQL text search dictionaries, configurations, templates, and parsers
- parse new text search resources from HCL
- document text search resources and link in docs README

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68c467c40a608331a77c4704ef886ba1