### PR TITLE
Add PostgreSQL tablespace support

### DIFF
--- a/docs/postgres/tablespace.md
+++ b/docs/postgres/tablespace.md
@@ -1,0 +1,27 @@
+# Tablespace
+
+Defines a PostgreSQL tablespace which stores data files in a specific location.
+
+```hcl
+tablespace "fastspace" {
+  location = "/mnt/ssd1"
+  owner    = "app_user"
+}
+```
+
+## Attributes
+- `name` (label): tablespace name.
+- `location` (string): directory for the tablespace.
+- `owner` (string, optional): role that owns the tablespace.
+- `options` (list of strings, optional): additional `WITH` options.
+- `comment` (string, optional): documentation comment.
+
+## Examples
+
+```hcl
+tablespace "fastspace" {
+  location = "/mnt/ssd1"
+  owner    = "app_user"
+  options  = ["seq_page_cost=1.0"]
+}
+```

--- a/src/backends/postgres.rs
+++ b/src/backends/postgres.rs
@@ -32,6 +32,18 @@ fn to_sql(cfg: &Config) -> Result<String> {
         }
     }
 
+    for t in &cfg.tablespaces {
+        out.push_str(&format!("{}\n\n", pg::Tablespace::from(t)));
+        if let Some(comment) = &t.comment {
+            let name = t.alt_name.clone().unwrap_or_else(|| t.name.clone());
+            out.push_str(&format!(
+                "COMMENT ON TABLESPACE {} IS {};\n\n",
+                pg::ident(&name),
+                pg::literal(comment)
+            ));
+        }
+    }
+
     for s in &cfg.schemas {
         out.push_str(&format!("{}\n\n", pg::Schema::from(s)));
         if let Some(comment) = &s.comment {

--- a/src/config.rs
+++ b/src/config.rs
@@ -93,6 +93,7 @@ pub enum ResourceKind {
     Sequences,
     Policies,
     Roles,
+    Tablespaces,
     Grants,
     Tests,
 }
@@ -116,6 +117,7 @@ impl fmt::Display for ResourceKind {
             ResourceKind::Sequences => "sequences",
             ResourceKind::Policies => "policies",
             ResourceKind::Roles => "roles",
+            ResourceKind::Tablespaces => "tablespaces",
             ResourceKind::Grants => "grants",
             ResourceKind::Tests => "tests",
         };
@@ -144,6 +146,7 @@ impl std::str::FromStr for ResourceKind {
             "sequences" => Ok(ResourceKind::Sequences),
             "policies" => Ok(ResourceKind::Policies),
             "roles" => Ok(ResourceKind::Roles),
+            "tablespaces" => Ok(ResourceKind::Tablespaces),
             "grants" => Ok(ResourceKind::Grants),
             "tests" => Ok(ResourceKind::Tests),
             _ => Err(format!("invalid resource kind: {}", s)),
@@ -173,6 +176,7 @@ impl TargetConfig {
                 ResourceKind::Sequences,
                 ResourceKind::Policies,
                 ResourceKind::Roles,
+                ResourceKind::Tablespaces,
                 ResourceKind::Grants,
                 ResourceKind::Tests,
             ]

--- a/src/frontend/ast/mod.rs
+++ b/src/frontend/ast/mod.rs
@@ -19,6 +19,7 @@ pub struct Config {
     pub materialized: Vec<AstMaterializedView>,
     pub policies: Vec<AstPolicy>,
     pub roles: Vec<AstRole>,
+    pub tablespaces: Vec<AstTablespace>,
     pub grants: Vec<AstGrant>,
     pub foreign_data_wrappers: Vec<AstForeignDataWrapper>,
     pub foreign_servers: Vec<AstForeignServer>,
@@ -222,6 +223,16 @@ pub struct AstRole {
     pub replication: bool,
     pub password: Option<String>,
     pub in_role: Vec<String>,
+    pub comment: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AstTablespace {
+    pub name: String,
+    pub alt_name: Option<String>,
+    pub location: String,
+    pub owner: Option<String>,
+    pub options: Vec<String>,
     pub comment: Option<String>,
 }
 

--- a/src/frontend/core.rs
+++ b/src/frontend/core.rs
@@ -1382,6 +1382,25 @@ fn load_file(
         )?;
     }
 
+    for blk in body.blocks().filter(|b| b.identifier() == "tablespace") {
+        let name = blk
+            .labels()
+            .get(0)
+            .ok_or_else(|| anyhow::anyhow!("tablespace block missing name label"))?
+            .as_str()
+            .to_string();
+        let for_each_expr = find_attr(blk.body(), "for_each");
+        let count_expr = find_attr(blk.body(), "count");
+        execute_for_each::<ast::AstTablespace>(
+            &name,
+            blk.body(),
+            &env,
+            &mut cfg,
+            for_each_expr,
+            count_expr,
+        )?;
+    }
+
     for blk in body.blocks().filter(|b| b.identifier() == "grant") {
         let name = blk
             .labels()

--- a/src/frontend/lower.rs
+++ b/src/frontend/lower.rs
@@ -20,6 +20,7 @@ pub fn lower_config(ast: ast::Config) -> ir::Config {
         materialized: ast.materialized.into_iter().map(Into::into).collect(),
         policies: ast.policies.into_iter().map(Into::into).collect(),
         roles: ast.roles.into_iter().map(Into::into).collect(),
+        tablespaces: ast.tablespaces.into_iter().map(Into::into).collect(),
         grants: ast.grants.into_iter().map(Into::into).collect(),
         foreign_data_wrappers: ast
             .foreign_data_wrappers
@@ -301,6 +302,19 @@ impl From<ast::AstRole> for ir::RoleSpec {
             password: r.password,
             in_role: r.in_role,
             comment: r.comment,
+        }
+    }
+}
+
+impl From<ast::AstTablespace> for ir::TablespaceSpec {
+    fn from(t: ast::AstTablespace) -> Self {
+        Self {
+            name: t.name,
+            alt_name: t.alt_name,
+            location: t.location,
+            owner: t.owner,
+            options: t.options,
+            comment: t.comment,
         }
     }
 }

--- a/src/frontend/resource_impls.rs
+++ b/src/frontend/resource_impls.rs
@@ -752,6 +752,35 @@ impl ForEachSupport for AstRole {
     }
 }
 
+// Tablespace implementation
+impl ForEachSupport for AstTablespace {
+    type Item = Self;
+
+    fn parse_one(name: &str, body: &Body, env: &EnvVars) -> Result<Self::Item> {
+        let alt_name = get_attr_string(body, "name", env)?;
+        let location = get_attr_string(body, "location", env)?
+            .context("tablespace 'location' is required")?;
+        let owner = get_attr_string(body, "owner", env)?;
+        let options = match find_attr(body, "options") {
+            Some(attr) => expr_to_string_vec(attr.expr(), env)?,
+            None => Vec::new(),
+        };
+        let comment = get_attr_string(body, "comment", env)?;
+        Ok(AstTablespace {
+            name: name.to_string(),
+            alt_name,
+            location,
+            owner,
+            options,
+            comment,
+        })
+    }
+
+    fn add_to_config(item: Self::Item, config: &mut Config) {
+        config.tablespaces.push(item);
+    }
+}
+
 // Grant implementation
 impl ForEachSupport for AstGrant {
     type Item = Self;

--- a/src/ir/config.rs
+++ b/src/ir/config.rs
@@ -20,6 +20,7 @@ pub struct Config {
     pub materialized: Vec<MaterializedViewSpec>,
     pub policies: Vec<PolicySpec>,
     pub roles: Vec<RoleSpec>,
+    pub tablespaces: Vec<TablespaceSpec>,
     pub grants: Vec<GrantSpec>,
     pub foreign_data_wrappers: Vec<ForeignDataWrapperSpec>,
     pub foreign_servers: Vec<ForeignServerSpec>,
@@ -225,6 +226,16 @@ pub struct RoleSpec {
     pub replication: bool,
     pub password: Option<String>,
     pub in_role: Vec<String>,
+    pub comment: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TablespaceSpec {
+    pub name: String,
+    pub alt_name: Option<String>,
+    pub location: String,
+    pub owner: Option<String>,
+    pub options: Vec<String>,
     pub comment: Option<String>,
 }
 

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -7,7 +7,7 @@ pub use config::{
     ForeignDataWrapperSpec, ForeignKeySpec, ForeignServerSpec, ForeignTableSpec,
     FunctionSpec, GrantSpec, IndexSpec, MaterializedViewSpec, OutputSpec,
     PartitionBySpec, PartitionSpec, PolicySpec, PrimaryKeySpec, PublicationSpec,
-    PublicationTableSpec, RoleSpec, SchemaSpec, SequenceSpec, StandaloneIndexSpec,
+    PublicationTableSpec, RoleSpec, TablespaceSpec, SchemaSpec, SequenceSpec, StandaloneIndexSpec,
     SubscriptionSpec, TableSpec, TestSpec, TextSearchConfigurationMappingSpec,
     TextSearchConfigurationSpec, TextSearchDictionarySpec, TextSearchParserSpec,
     TextSearchTemplateSpec, TriggerSpec, ViewSpec,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ use crate::frontend::env::EnvVars;
 pub use ir::{
     AggregateSpec, CollationSpec, CompositeTypeSpec, Config, DomainSpec, EnumSpec, EventTriggerSpec,
     ExtensionSpec, FunctionSpec, GrantSpec, MaterializedViewSpec, OutputSpec, PolicySpec, RoleSpec,
-    SchemaSpec, SequenceSpec, TableSpec, TriggerSpec, ViewSpec,
+    TablespaceSpec, SchemaSpec, SequenceSpec, TableSpec, TriggerSpec, ViewSpec,
 };
 
 // Loader abstraction: lets callers control how files are read.
@@ -70,6 +70,7 @@ where
         materialized: maybe!(Materialized, materialized),
         policies: maybe!(Policies, policies),
         roles: maybe!(Roles, roles),
+        tablespaces: maybe!(Tablespaces, tablespaces),
         grants: maybe!(Grants, grants),
         tests: maybe!(Tests, tests),
         outputs: cfg.outputs.clone(),

--- a/src/postgres/mod.rs
+++ b/src/postgres/mod.rs
@@ -98,6 +98,43 @@ impl fmt::Display for Role {
 }
 
 #[derive(Debug, Clone)]
+pub struct Tablespace {
+    pub name: String,
+    pub location: String,
+    pub owner: Option<String>,
+    pub options: Vec<String>,
+}
+
+impl From<&crate::ir::TablespaceSpec> for Tablespace {
+    fn from(t: &crate::ir::TablespaceSpec) -> Self {
+        Self {
+            name: t.alt_name.clone().unwrap_or_else(|| t.name.clone()),
+            location: t.location.clone(),
+            owner: t.owner.clone(),
+            options: t.options.clone(),
+        }
+    }
+}
+
+impl fmt::Display for Tablespace {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "CREATE TABLESPACE {} LOCATION {}",
+            ident(&self.name),
+            literal(&self.location)
+        )?;
+        if let Some(owner) = &self.owner {
+            write!(f, " OWNER {}", ident(owner))?;
+        }
+        if !self.options.is_empty() {
+            write!(f, " WITH ({})", self.options.join(", "))?;
+        }
+        write!(f, ";")
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct Extension {
     pub name: String,
     pub if_not_exists: bool,


### PR DESCRIPTION
## Summary
- add tablespace resource to IR and parsing
- generate CREATE TABLESPACE SQL for Postgres backend
- document tablespace usage

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68c46b1ce7c883319649ff3f0402448d