### PR TITLE
Add publication and subscription resources

### DIFF
--- a/docs/postgres/publication.md
+++ b/docs/postgres/publication.md
@@ -8,6 +8,7 @@ publication "pub" {
     { schema = "public", table = "t" }
   ]
   publish = ["insert", "update"]
+  comment = "main publication"
 }
 ```
 
@@ -29,5 +30,6 @@ publication "pub_some" {
     { table = "posts" }
   ]
   publish = ["insert", "update"]
+  comment = "replicate some tables"
 }
 ```

--- a/docs/postgres/subscription.md
+++ b/docs/postgres/subscription.md
@@ -6,6 +6,7 @@ Creates a replication subscription.
 subscription "sub" {
   connection   = "host=localhost"
   publications = ["pub"]
+  comment      = "subscribes to pub"
 }
 ```
 
@@ -21,5 +22,6 @@ subscription "sub" {
 subscription "sub_main" {
   connection = "host=replica dbname=app user=rep password=secret"
   publications = ["pub_all"]
+  comment     = "main subscription"
 }
 ```

--- a/src/config.rs
+++ b/src/config.rs
@@ -96,6 +96,8 @@ pub enum ResourceKind {
     Roles,
     Tablespaces,
     Grants,
+    Publications,
+    Subscriptions,
     Tests,
 }
 
@@ -121,6 +123,8 @@ impl fmt::Display for ResourceKind {
             ResourceKind::Roles => "roles",
             ResourceKind::Tablespaces => "tablespaces",
             ResourceKind::Grants => "grants",
+            ResourceKind::Publications => "publications",
+            ResourceKind::Subscriptions => "subscriptions",
             ResourceKind::Tests => "tests",
         };
         write!(f, "{}", s)
@@ -151,6 +155,8 @@ impl std::str::FromStr for ResourceKind {
             "roles" => Ok(ResourceKind::Roles),
             "tablespaces" => Ok(ResourceKind::Tablespaces),
             "grants" => Ok(ResourceKind::Grants),
+            "publications" => Ok(ResourceKind::Publications),
+            "subscriptions" => Ok(ResourceKind::Subscriptions),
             "tests" => Ok(ResourceKind::Tests),
             _ => Err(format!("invalid resource kind: {}", s)),
         }
@@ -182,6 +188,8 @@ impl TargetConfig {
                 ResourceKind::Roles,
                 ResourceKind::Tablespaces,
                 ResourceKind::Grants,
+                ResourceKind::Publications,
+                ResourceKind::Subscriptions,
                 ResourceKind::Tests,
             ]
             .into_iter()
@@ -250,7 +258,7 @@ mod tests {
         assert!(include_set.contains(&ResourceKind::EventTriggers));
         assert!(include_set.contains(&ResourceKind::Aggregates));
         assert!(include_set.contains(&ResourceKind::Collations));
-        assert_eq!(include_set.len(), 18); // All resource types
+        assert_eq!(include_set.len(), 22); // All resource types
     }
 
     #[test]

--- a/src/frontend/ast/mod.rs
+++ b/src/frontend/ast/mod.rs
@@ -29,6 +29,8 @@ pub struct Config {
     pub text_search_configurations: Vec<AstTextSearchConfiguration>,
     pub text_search_templates: Vec<AstTextSearchTemplate>,
     pub text_search_parsers: Vec<AstTextSearchParser>,
+    pub publications: Vec<AstPublication>,
+    pub subscriptions: Vec<AstSubscription>,
     pub tests: Vec<AstTest>,
     pub outputs: Vec<AstOutput>,
 }
@@ -438,6 +440,31 @@ pub struct AstTextSearchParser {
     pub end: String,
     pub headline: Option<String>,
     pub lextypes: String,
+    pub comment: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AstPublication {
+    pub name: String,
+    pub alt_name: Option<String>,
+    pub all_tables: bool,
+    pub tables: Vec<AstPublicationTable>,
+    pub publish: Vec<String>,
+    pub comment: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AstPublicationTable {
+    pub schema: Option<String>,
+    pub table: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct AstSubscription {
+    pub name: String,
+    pub alt_name: Option<String>,
+    pub connection: String,
+    pub publications: Vec<String>,
     pub comment: Option<String>,
 }
 

--- a/src/frontend/core.rs
+++ b/src/frontend/core.rs
@@ -1439,6 +1439,44 @@ fn load_file(
         )?;
     }
 
+    for blk in body.blocks().filter(|b| b.identifier() == "publication") {
+        let name = blk
+            .labels()
+            .get(0)
+            .ok_or_else(|| anyhow::anyhow!("publication block missing name label"))?
+            .as_str()
+            .to_string();
+        let for_each_expr = find_attr(blk.body(), "for_each");
+        let count_expr = find_attr(blk.body(), "count");
+        execute_for_each::<ast::AstPublication>(
+            &name,
+            blk.body(),
+            &env,
+            &mut cfg,
+            for_each_expr,
+            count_expr,
+        )?;
+    }
+
+    for blk in body.blocks().filter(|b| b.identifier() == "subscription") {
+        let name = blk
+            .labels()
+            .get(0)
+            .ok_or_else(|| anyhow::anyhow!("subscription block missing name label"))?
+            .as_str()
+            .to_string();
+        let for_each_expr = find_attr(blk.body(), "for_each");
+        let count_expr = find_attr(blk.body(), "count");
+        execute_for_each::<ast::AstSubscription>(
+            &name,
+            blk.body(),
+            &env,
+            &mut cfg,
+            for_each_expr,
+            count_expr,
+        )?;
+    }
+
     for blk in body.blocks().filter(|b| b.identifier() == "test") {
         let name = blk
             .labels()

--- a/src/frontend/lower.rs
+++ b/src/frontend/lower.rs
@@ -58,8 +58,8 @@ pub fn lower_config(ast: ast::Config) -> ir::Config {
             .into_iter()
             .map(Into::into)
             .collect(),
-        publications: vec![],
-        subscriptions: vec![],
+        publications: ast.publications.into_iter().map(Into::into).collect(),
+        subscriptions: ast.subscriptions.into_iter().map(Into::into).collect(),
         tests: ast.tests.into_iter().map(Into::into).collect(),
         outputs: ast.outputs.into_iter().map(Into::into).collect(),
     }
@@ -572,6 +572,40 @@ impl From<ast::AstStandaloneIndex> for ir::StandaloneIndexSpec {
             orders: i.orders,
             operator_classes: i.operator_classes,
             unique: i.unique,
+        }
+    }
+}
+
+impl From<ast::AstPublication> for ir::PublicationSpec {
+    fn from(p: ast::AstPublication) -> Self {
+        Self {
+            name: p.name,
+            alt_name: p.alt_name,
+            all_tables: p.all_tables,
+            tables: p.tables.into_iter().map(Into::into).collect(),
+            publish: p.publish,
+            comment: p.comment,
+        }
+    }
+}
+
+impl From<ast::AstPublicationTable> for ir::PublicationTableSpec {
+    fn from(t: ast::AstPublicationTable) -> Self {
+        Self {
+            schema: t.schema,
+            table: t.table,
+        }
+    }
+}
+
+impl From<ast::AstSubscription> for ir::SubscriptionSpec {
+    fn from(s: ast::AstSubscription) -> Self {
+        Self {
+            name: s.name,
+            alt_name: s.alt_name,
+            connection: s.connection,
+            publications: s.publications,
+            comment: s.comment,
         }
     }
 }


### PR DESCRIPTION
## Summary
- add `AstPublication` and `AstSubscription` with parsing
- lower publications and subscriptions to IR
- document replication publications and subscriptions

## Testing
- `cargo check 2>&1 | cat`
- `cargo test 2>&1 | cat`


------
https://chatgpt.com/codex/tasks/task_e_68c473c1c7148331bc9d8fead4b42d17