### PR TITLE
Add foreign key lint checks

### DIFF
--- a/docs/linting.md
+++ b/docs/linting.md
@@ -9,6 +9,8 @@
 - destructive-change: foreign keys using ON DELETE/ON UPDATE CASCADE.
 - unused-index: indexes that duplicate a table's primary key.
 - long-identifier: table, column, or index names longer than 63 characters.
+- missing-foreign-key-index: foreign key columns should be indexed.
+- column-type-mismatch: foreign key column types must match referenced columns.
 
 Suppress a rule for a specific table or column with `lint_ignore`:
 
@@ -19,6 +21,25 @@ table "users" {
   column "ID" {
     type = "int"
     lint_ignore = ["naming-convention"]
+  }
+}
+```
+
+Additional suppressions:
+
+```hcl
+table "orders" {
+  lint_ignore = ["missing-foreign-key-index"]
+
+  column "user_id" {
+    type = "text"
+    lint_ignore = ["column-type-mismatch"]
+  }
+
+  foreign_key {
+    columns = ["user_id"]
+    ref_table = "users"
+    ref_columns = ["id"]
   }
 }
 ```

--- a/src/lint/column_type_mismatch.rs
+++ b/src/lint/column_type_mismatch.rs
@@ -1,0 +1,154 @@
+use super::{LintCheck, LintMessage, LintSeverity};
+use crate::ir::{Config, TableSpec};
+
+pub struct ColumnTypeMismatch;
+
+impl ColumnTypeMismatch {
+    fn ignored(table: &TableSpec, column: &str, rule: &str) -> bool {
+        if table.lint_ignore.iter().any(|i| i == rule) {
+            return true;
+        }
+        if let Some(col) = table.columns.iter().find(|c| &c.name == column) {
+            if col.lint_ignore.iter().any(|i| i == rule) {
+                return true;
+            }
+        }
+        false
+    }
+}
+
+impl LintCheck for ColumnTypeMismatch {
+    fn name(&self) -> &'static str {
+        "column-type-mismatch"
+    }
+
+    fn run(&self, cfg: &Config) -> Vec<LintMessage> {
+        let mut msgs = Vec::new();
+        for table in &cfg.tables {
+            for fk in &table.foreign_keys {
+                for (col_name, ref_col_name) in fk.columns.iter().zip(&fk.ref_columns) {
+                    if Self::ignored(table, col_name, self.name()) {
+                        continue;
+                    }
+                    let Some(src_col) = table.columns.iter().find(|c| &c.name == col_name) else {
+                        continue;
+                    };
+                    let Some(ref_table) = cfg
+                        .tables
+                        .iter()
+                        .find(|t| t.alt_name.as_ref().unwrap_or(&t.name) == &fk.ref_table)
+                    else {
+                        continue;
+                    };
+                    let Some(ref_col) = ref_table.columns.iter().find(|c| &c.name == ref_col_name) else {
+                        continue;
+                    };
+                    let src_ty = src_col
+                        .db_type
+                        .as_deref()
+                        .unwrap_or(&src_col.r#type)
+                        .to_lowercase();
+                    let ref_ty = ref_col
+                        .db_type
+                        .as_deref()
+                        .unwrap_or(&ref_col.r#type)
+                        .to_lowercase();
+                    if src_ty != ref_ty {
+                        msgs.push(LintMessage {
+                            check: self.name(),
+                            message: format!(
+                                "column '{}.{}' type '{}' does not match '{}.{}' type '{}'",
+                                table.name, col_name, src_ty, ref_table.name, ref_col_name, ref_ty
+                            ),
+                            severity: LintSeverity::Error,
+                        });
+                    }
+                }
+            }
+        }
+        msgs
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ir::{ColumnSpec, Config, ForeignKeySpec, TableSpec};
+    use crate::lint::{run_with_checks, LintSettings};
+
+    #[test]
+    fn detects_type_mismatch() {
+        let referenced = TableSpec {
+            name: "ref".into(),
+            alt_name: None,
+            schema: None,
+            if_not_exists: false,
+            columns: vec![ColumnSpec {
+                name: "id".into(),
+                r#type: "int".into(),
+                nullable: false,
+                default: None,
+                db_type: None,
+                lint_ignore: vec![],
+                comment: None,
+                count: 1,
+            }],
+            primary_key: None,
+            indexes: vec![],
+            checks: vec![],
+            foreign_keys: vec![],
+            partition_by: None,
+            partitions: vec![],
+            back_references: vec![],
+            lint_ignore: vec![],
+            comment: None,
+            map: None,
+        };
+        let table = TableSpec {
+            name: "t".into(),
+            alt_name: None,
+            schema: None,
+            if_not_exists: false,
+            columns: vec![ColumnSpec {
+                name: "ref_id".into(),
+                r#type: "text".into(),
+                nullable: false,
+                default: None,
+                db_type: None,
+                lint_ignore: vec![],
+                comment: None,
+                count: 1,
+            }],
+            primary_key: None,
+            indexes: vec![],
+            checks: vec![],
+            foreign_keys: vec![ForeignKeySpec {
+                name: None,
+                columns: vec!["ref_id".into()],
+                ref_schema: None,
+                ref_table: "ref".into(),
+                ref_columns: vec!["id".into()],
+                on_delete: None,
+                on_update: None,
+                back_reference_name: None,
+            }],
+            partition_by: None,
+            partitions: vec![],
+            back_references: vec![],
+            lint_ignore: vec![],
+            comment: None,
+            map: None,
+        };
+        let cfg = Config {
+            tables: vec![referenced, table],
+            ..Default::default()
+        };
+        let msgs = run_with_checks(
+            &cfg,
+            vec![Box::new(ColumnTypeMismatch)],
+            &LintSettings::default(),
+        );
+        assert!(msgs.iter().any(|m| m.check == "column-type-mismatch"));
+    }
+}
+

--- a/src/lint/missing_foreign_key_index.rs
+++ b/src/lint/missing_foreign_key_index.rs
@@ -1,0 +1,155 @@
+use super::{LintCheck, LintMessage, LintSeverity};
+use crate::ir::{Config, TableSpec};
+
+pub struct MissingForeignKeyIndex;
+
+impl MissingForeignKeyIndex {
+    fn ignored(table: &TableSpec, columns: &[String], rule: &str) -> bool {
+        if table.lint_ignore.iter().any(|i| i == rule) {
+            return true;
+        }
+        for col_name in columns {
+            if let Some(col) = table.columns.iter().find(|c| &c.name == col_name) {
+                if col.lint_ignore.iter().any(|i| i == rule) {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    fn has_index(cfg: &Config, table: &TableSpec, columns: &[String]) -> bool {
+        let matches = |idx_cols: &[String]| {
+            if idx_cols.len() < columns.len() {
+                return false;
+            }
+            idx_cols.iter().zip(columns).all(|(a, b)| a == b)
+        };
+        if let Some(pk) = &table.primary_key {
+            if matches(&pk.columns) {
+                return true;
+            }
+        }
+        if table.indexes.iter().any(|i| matches(&i.columns)) {
+            return true;
+        }
+        let tbl_name = table.alt_name.as_ref().unwrap_or(&table.name);
+        let schema = table.schema.as_deref().unwrap_or("public");
+        cfg.indexes
+            .iter()
+            .filter(|i| i.table == *tbl_name && i.schema.as_deref().unwrap_or("public") == schema)
+            .any(|i| matches(&i.columns))
+    }
+}
+
+impl LintCheck for MissingForeignKeyIndex {
+    fn name(&self) -> &'static str {
+        "missing-foreign-key-index"
+    }
+
+    fn run(&self, cfg: &Config) -> Vec<LintMessage> {
+        let mut msgs = Vec::new();
+        for table in &cfg.tables {
+            for fk in &table.foreign_keys {
+                if Self::ignored(table, &fk.columns, self.name()) {
+                    continue;
+                }
+                if !Self::has_index(cfg, table, &fk.columns) {
+                    msgs.push(LintMessage {
+                        check: self.name(),
+                        message: format!(
+                            "foreign key on '{}.{}' has no index",
+                            table.name,
+                            fk.columns.join(",")
+                        ),
+                        severity: LintSeverity::Error,
+                    });
+                }
+            }
+        }
+        msgs
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ir::{ColumnSpec, Config, ForeignKeySpec, TableSpec};
+    use crate::lint::{run_with_checks, LintSettings};
+
+    #[test]
+    fn detects_missing_fk_index() {
+        let referenced = TableSpec {
+            name: "ref".into(),
+            alt_name: None,
+            schema: None,
+            if_not_exists: false,
+            columns: vec![ColumnSpec {
+                name: "id".into(),
+                r#type: "int".into(),
+                nullable: false,
+                default: None,
+                db_type: None,
+                lint_ignore: vec![],
+                comment: None,
+                count: 1,
+            }],
+            primary_key: None,
+            indexes: vec![],
+            checks: vec![],
+            foreign_keys: vec![],
+            partition_by: None,
+            partitions: vec![],
+            back_references: vec![],
+            lint_ignore: vec![],
+            comment: None,
+            map: None,
+        };
+        let table = TableSpec {
+            name: "t".into(),
+            alt_name: None,
+            schema: None,
+            if_not_exists: false,
+            columns: vec![ColumnSpec {
+                name: "ref_id".into(),
+                r#type: "int".into(),
+                nullable: false,
+                default: None,
+                db_type: None,
+                lint_ignore: vec![],
+                comment: None,
+                count: 1,
+            }],
+            primary_key: None,
+            indexes: vec![],
+            checks: vec![],
+            foreign_keys: vec![ForeignKeySpec {
+                name: None,
+                columns: vec!["ref_id".into()],
+                ref_schema: None,
+                ref_table: "ref".into(),
+                ref_columns: vec!["id".into()],
+                on_delete: None,
+                on_update: None,
+                back_reference_name: None,
+            }],
+            partition_by: None,
+            partitions: vec![],
+            back_references: vec![],
+            lint_ignore: vec![],
+            comment: None,
+            map: None,
+        };
+        let cfg = Config {
+            tables: vec![referenced, table],
+            ..Default::default()
+        };
+        let msgs = run_with_checks(
+            &cfg,
+            vec![Box::new(MissingForeignKeyIndex)],
+            &LintSettings::default(),
+        );
+        assert!(msgs.iter().any(|m| m.check == "missing-foreign-key-index"));
+    }
+}
+

--- a/src/lint/mod.rs
+++ b/src/lint/mod.rs
@@ -4,13 +4,17 @@ use std::collections::HashMap;
 
 mod destructive_change;
 mod long_identifier;
+mod column_type_mismatch;
 mod sql_syntax;
 mod unused_index;
+mod missing_foreign_key_index;
 
 use destructive_change::DestructiveChange;
 use long_identifier::LongIdentifier;
+use column_type_mismatch::ColumnTypeMismatch;
 use sql_syntax::SqlSyntax;
 use unused_index::UnusedIndex;
+use missing_foreign_key_index::MissingForeignKeyIndex;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -42,6 +46,8 @@ pub fn run(cfg: &Config, settings: &LintSettings) -> Vec<LintMessage> {
     let checks: Vec<Box<dyn LintCheck>> = vec![
         Box::new(NamingConvention),
         Box::new(MissingIndex),
+        Box::new(MissingForeignKeyIndex),
+        Box::new(ColumnTypeMismatch),
         Box::new(ForbidSerial),
         Box::new(PrimaryKeyNotNull),
         Box::new(DestructiveChange),


### PR DESCRIPTION
## Summary
- add lint for missing foreign key indexes
- add lint for foreign key column type mismatches
- document new lint rules and suppression examples

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68c473d4b4888331898384eb5e98cf81