### PR TITLE
Add STATISTICS resource support

### DIFF
--- a/docs/Readme.md
+++ b/docs/Readme.md
@@ -47,3 +47,4 @@ We aim to support all major PostgreSQL features. See the reference docs:
 - [Text Search Configuration](postgres/text_search_configuration.md)
 - [Text Search Template](postgres/text_search_template.md)
 - [Text Search Parser](postgres/text_search_parser.md)
+- [Statistics](postgres/statistics.md)

--- a/docs/postgres/statistics.md
+++ b/docs/postgres/statistics.md
@@ -1,0 +1,30 @@
+# Statistics
+
+Defines an extended statistics object for a table.
+
+```hcl
+statistics "orders_stats" {
+  schema  = "public"
+  table   = "orders"
+  columns = ["region", "product"]
+  kinds   = ["ndistinct", "dependencies"]
+  comment = "Multi-column statistics for orders"
+}
+```
+
+## Attributes
+- `name` (label): statistics name.
+- `schema` (string, optional): schema of the table. Defaults to `public`.
+- `table` (string): table the statistics are based on.
+- `columns` (array of strings): columns to include in the statistics.
+- `kinds` (array of strings, optional): statistics kinds such as `ndistinct`, `dependencies`, or `mcv`.
+- `comment` (string, optional): documentation comment.
+
+## Examples
+
+```hcl
+statistics "orders_stats" {
+  table   = "orders"
+  columns = ["region", "product"]
+}
+```

--- a/examples/statistics.hcl
+++ b/examples/statistics.hcl
@@ -1,0 +1,13 @@
+table "orders" {
+  column "region" { type = "text" }
+  column "product" { type = "text" }
+  primary_key { columns = ["region", "product"] }
+}
+
+statistics "orders_stats" {
+  schema = "public"
+  table  = "orders"
+  columns = ["region", "product"]
+  kinds   = ["ndistinct", "dependencies"]
+  comment = "Multi-column statistics for orders"
+}

--- a/src/backends/postgres.rs
+++ b/src/backends/postgres.rs
@@ -269,6 +269,20 @@ fn to_sql(cfg: &Config) -> Result<String> {
         out.push_str(&format!("{}\n\n", pg::Index::from_standalone(idx)));
     }
 
+    for s in &cfg.statistics {
+        out.push_str(&format!("{}\n\n", pg::Statistics::from(s)));
+        if let Some(comment) = &s.comment {
+            let schema = s.schema.clone().unwrap_or_else(|| "public".to_string());
+            let name = s.alt_name.clone().unwrap_or_else(|| s.name.clone());
+            out.push_str(&format!(
+                "COMMENT ON STATISTICS {}.{} IS {};\n\n",
+                pg::ident(&schema),
+                pg::ident(&name),
+                pg::literal(comment)
+            ));
+        }
+    }
+
     for p in &cfg.policies {
         out.push_str(&format!("{}\n\n", pg::Policy::from(p)));
         if let Some(comment) = &p.comment {

--- a/src/frontend/ast/mod.rs
+++ b/src/frontend/ast/mod.rs
@@ -18,6 +18,7 @@ pub struct Config {
     pub types: Vec<AstCompositeType>,
     pub tables: Vec<AstTable>,
     pub indexes: Vec<AstStandaloneIndex>,
+    pub statistics: Vec<AstStatistics>,
     pub views: Vec<AstView>,
     pub materialized: Vec<AstMaterializedView>,
     pub policies: Vec<AstPolicy>,
@@ -422,6 +423,17 @@ pub struct AstStandaloneIndex {
     pub orders: Vec<String>,
     pub operator_classes: Vec<String>,
     pub unique: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct AstStatistics {
+    pub name: String,
+    pub alt_name: Option<String>,
+    pub schema: Option<String>,
+    pub table: String,
+    pub columns: Vec<String>,
+    pub kinds: Vec<String>,
+    pub comment: Option<String>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/frontend/lower.rs
+++ b/src/frontend/lower.rs
@@ -19,6 +19,7 @@ pub fn lower_config(ast: ast::Config) -> ir::Config {
         types: ast.types.into_iter().map(Into::into).collect(),
         tables: ast.tables.into_iter().map(Into::into).collect(),
         indexes: ast.indexes.into_iter().map(Into::into).collect(),
+        statistics: ast.statistics.into_iter().map(Into::into).collect(),
         views: ast.views.into_iter().map(Into::into).collect(),
         materialized: ast.materialized.into_iter().map(Into::into).collect(),
         policies: ast.policies.into_iter().map(Into::into).collect(),
@@ -608,6 +609,20 @@ impl From<ast::AstStandaloneIndex> for ir::StandaloneIndexSpec {
             orders: i.orders,
             operator_classes: i.operator_classes,
             unique: i.unique,
+        }
+    }
+}
+
+impl From<ast::AstStatistics> for ir::StatisticsSpec {
+    fn from(s: ast::AstStatistics) -> Self {
+        Self {
+            name: s.name,
+            alt_name: s.alt_name,
+            schema: s.schema,
+            table: s.table,
+            columns: s.columns,
+            kinds: s.kinds,
+            comment: s.comment,
         }
     }
 }

--- a/src/frontend/resource_impls.rs
+++ b/src/frontend/resource_impls.rs
@@ -971,6 +971,40 @@ impl ForEachSupport for AstStandaloneIndex {
     }
 }
 
+// Statistics implementation
+impl ForEachSupport for AstStatistics {
+    type Item = Self;
+
+    fn parse_one(name: &str, body: &Body, env: &EnvVars) -> Result<Self::Item> {
+        let alt_name = get_attr_string(body, "name", env)?;
+        let schema = get_attr_string(body, "schema", env)?;
+        let table = get_attr_string(body, "table", env)?
+            .context("statistics 'table' is required")?;
+        let columns = match find_attr(body, "columns") {
+            Some(attr) => expr_to_string_vec(attr.expr(), env)?,
+            None => bail!("statistics requires columns = [..]"),
+        };
+        let kinds = match find_attr(body, "kinds") {
+            Some(attr) => expr_to_string_vec(attr.expr(), env)?,
+            None => Vec::new(),
+        };
+        let comment = get_attr_string(body, "comment", env)?;
+        Ok(AstStatistics {
+            name: name.to_string(),
+            alt_name,
+            schema,
+            table,
+            columns,
+            kinds,
+            comment,
+        })
+    }
+
+    fn add_to_config(item: Self::Item, config: &mut Config) {
+        config.statistics.push(item);
+    }
+}
+
 // Foreign Data Wrapper implementation
 impl ForEachSupport for AstForeignDataWrapper {
     type Item = Self;

--- a/src/ir/config.rs
+++ b/src/ir/config.rs
@@ -19,6 +19,7 @@ pub struct Config {
     pub types: Vec<CompositeTypeSpec>,
     pub tables: Vec<TableSpec>,
     pub indexes: Vec<StandaloneIndexSpec>,
+    pub statistics: Vec<StatisticsSpec>,
     pub views: Vec<ViewSpec>,
     pub materialized: Vec<MaterializedViewSpec>,
     pub policies: Vec<PolicySpec>,
@@ -447,6 +448,17 @@ pub struct StandaloneIndexSpec {
     pub orders: Vec<String>,
     pub operator_classes: Vec<String>,
     pub unique: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct StatisticsSpec {
+    pub name: String,
+    pub alt_name: Option<String>,
+    pub schema: Option<String>,
+    pub table: String,
+    pub columns: Vec<String>,
+    pub kinds: Vec<String>,
+    pub comment: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -8,7 +8,7 @@ pub use config::{
     FunctionSpec, ProcedureSpec, GrantSpec, IndexSpec, MaterializedViewSpec, OutputSpec,
     PartitionBySpec, PartitionSpec, PolicySpec, PrimaryKeySpec, PublicationSpec,
     PublicationTableSpec, RoleSpec, TablespaceSpec, SchemaSpec, SequenceSpec, StandaloneIndexSpec,
-    SubscriptionSpec, TableSpec, TestSpec, TextSearchConfigurationMappingSpec,
+    StatisticsSpec, SubscriptionSpec, TableSpec, TestSpec, TextSearchConfigurationMappingSpec,
     TextSearchConfigurationSpec, TextSearchDictionarySpec, TextSearchParserSpec,
     TextSearchTemplateSpec, TriggerSpec, ViewSpec,
 };


### PR DESCRIPTION
## Summary
- add AST and IR types plus parser support for STATISTICS resources
- emit CREATE STATISTICS in Postgres backend with comment handling
- document STATISTICS usage and provide example

## Testing
- `cargo check 2>&1 | cat`

------
https://chatgpt.com/codex/tasks/task_e_68c48062e04483319162a4a609e4da50