### PR TITLE
Add pglite test backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,11 +27,12 @@ postgres = "0.19"
 log = "0.4"
 env_logger = "0.11"
 url = "2"
-postgres-protocol = { version = "0.6", optional = true }
-bytes = { version = "1", optional = true }
-fallible-iterator = { version = "0.2", optional = true }
-tokio = { version = "1", features = ["rt-multi-thread"], optional = true }
+postgres-protocol = "0.6"
+fallible-iterator = "0.2"
+bytes = "1"
+tokio = { version = "1", features = ["rt-multi-thread"] }
 pg_query = "6.1"
+pglite-oxide = { git = "https://github.com/f0rr0/pglite-oxide" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -24,7 +24,7 @@ pub fn generate_header_comment(backend_name: &str, comment_style: CommentStyle) 
          Generated: {}",
         backend_name, timestamp
     );
-    
+
     match comment_style {
         CommentStyle::Sql => {
             let lines: Vec<String> = warning.lines().map(|line| format!("-- {}", line)).collect();

--- a/src/backends/postgres.rs
+++ b/src/backends/postgres.rs
@@ -1,4 +1,4 @@
-use super::{Backend, CommentStyle, generate_header_comment};
+use super::{generate_header_comment, Backend, CommentStyle};
 use crate::{ir::*, postgres as pg};
 use anyhow::Result;
 

--- a/src/backends/prisma.rs
+++ b/src/backends/prisma.rs
@@ -1,4 +1,4 @@
-use super::{Backend, CommentStyle, generate_header_comment};
+use super::{generate_header_comment, Backend, CommentStyle};
 use crate::ir::{ColumnSpec, Config, EnumSpec, TableSpec};
 use crate::passes::validate::{find_enum_for_type, is_likely_enum};
 use crate::prisma as ps;
@@ -79,9 +79,7 @@ fn model_to_ast(t: &TableSpec, enums: &[EnumSpec], strict: bool) -> Result<ps::M
             .attributes
             .push(ps::BlockAttribute::Map(table_name.clone()));
     } else if let Some(map) = &t.map {
-        model
-            .attributes
-            .push(ps::BlockAttribute::Map(map.clone()));
+        model.attributes.push(ps::BlockAttribute::Map(map.clone()));
     }
 
     Ok(model)

--- a/src/frontend/core.rs
+++ b/src/frontend/core.rs
@@ -357,9 +357,9 @@ fn resolve_traversal_value(tr: &Traversal, env: &EnvVars) -> Result<Value> {
             let Some(TraversalOperator::GetAttr(name)) = it.next() else {
                 bail!("expected count.index");
             };
-            let idx = env
-                .count
-                .ok_or_else(|| anyhow::anyhow!("'count' is only available inside count iterations"))?;
+            let idx = env.count.ok_or_else(|| {
+                anyhow::anyhow!("'count' is only available inside count iterations")
+            })?;
             match name.as_str() {
                 "index" => {
                     if it.next().is_some() {
@@ -378,7 +378,11 @@ fn resolve_traversal_value(tr: &Traversal, env: &EnvVars) -> Result<Value> {
                         TraversalOperator::GetAttr(attr) => {
                             if let Value::Object(map) = current {
                                 current = map.get(attr.as_str()).cloned().ok_or_else(|| {
-                                    anyhow::anyhow!("unknown attribute '{}' on variable '{}'", attr, root)
+                                    anyhow::anyhow!(
+                                        "unknown attribute '{}' on variable '{}'",
+                                        attr,
+                                        root
+                                    )
                                 })?;
                             } else {
                                 bail!("cannot access attribute '{}' on non-object value for variable '{}'", attr, root);
@@ -1363,7 +1367,10 @@ fn load_file(
         )?;
     }
 
-    for blk in body.blocks().filter(|b| b.identifier() == "foreign_data_wrapper") {
+    for blk in body
+        .blocks()
+        .filter(|b| b.identifier() == "foreign_data_wrapper")
+    {
         let name = blk
             .labels()
             .get(0)

--- a/src/frontend/lower.rs
+++ b/src/frontend/lower.rs
@@ -31,16 +31,8 @@ pub fn lower_config(ast: ast::Config) -> ir::Config {
             .into_iter()
             .map(Into::into)
             .collect(),
-        foreign_servers: ast
-            .foreign_servers
-            .into_iter()
-            .map(Into::into)
-            .collect(),
-        foreign_tables: ast
-            .foreign_tables
-            .into_iter()
-            .map(Into::into)
-            .collect(),
+        foreign_servers: ast.foreign_servers.into_iter().map(Into::into).collect(),
+        foreign_tables: ast.foreign_tables.into_iter().map(Into::into).collect(),
         text_search_dictionaries: ast
             .text_search_dictionaries
             .into_iter()
@@ -442,9 +434,7 @@ impl From<ast::AstTextSearchDictionary> for ir::TextSearchDictionarySpec {
     }
 }
 
-impl From<ast::AstTextSearchConfigurationMapping>
-    for ir::TextSearchConfigurationMappingSpec
-{
+impl From<ast::AstTextSearchConfigurationMapping> for ir::TextSearchConfigurationMappingSpec {
     fn from(m: ast::AstTextSearchConfigurationMapping) -> Self {
         Self {
             tokens: m.tokens,

--- a/src/frontend/resource_impls.rs
+++ b/src/frontend/resource_impls.rs
@@ -611,7 +611,8 @@ impl ForEachSupport for AstRule {
         let event = get_attr_string(body, "event", env)?.context("rule 'event' is required")?;
         let r#where = get_attr_string(body, "where", env)?;
         let instead = get_attr_bool(body, "instead", env)?.unwrap_or(false);
-        let command = get_attr_string(body, "command", env)?.context("rule 'command' is required")?;
+        let command =
+            get_attr_string(body, "command", env)?.context("rule 'command' is required")?;
         let comment = get_attr_string(body, "comment", env)?;
         Ok(AstRule {
             name: name.to_string(),
@@ -863,8 +864,8 @@ impl ForEachSupport for AstTablespace {
 
     fn parse_one(name: &str, body: &Body, env: &EnvVars) -> Result<Self::Item> {
         let alt_name = get_attr_string(body, "name", env)?;
-        let location = get_attr_string(body, "location", env)?
-            .context("tablespace 'location' is required")?;
+        let location =
+            get_attr_string(body, "location", env)?.context("tablespace 'location' is required")?;
         let owner = get_attr_string(body, "owner", env)?;
         let options = match find_attr(body, "options") {
             Some(attr) => expr_to_string_vec(attr.expr(), env)?,
@@ -978,8 +979,8 @@ impl ForEachSupport for AstStatistics {
     fn parse_one(name: &str, body: &Body, env: &EnvVars) -> Result<Self::Item> {
         let alt_name = get_attr_string(body, "name", env)?;
         let schema = get_attr_string(body, "schema", env)?;
-        let table = get_attr_string(body, "table", env)?
-            .context("statistics 'table' is required")?;
+        let table =
+            get_attr_string(body, "table", env)?.context("statistics 'table' is required")?;
         let columns = match find_attr(body, "columns") {
             Some(attr) => expr_to_string_vec(attr.expr(), env)?,
             None => bail!("statistics requires columns = [..]"),
@@ -1071,8 +1072,8 @@ impl ForEachSupport for AstForeignTable {
     fn parse_one(name: &str, body: &Body, env: &EnvVars) -> Result<Self::Item> {
         let alt_name = get_attr_string(body, "name", env)?;
         let schema = get_attr_string(body, "schema", env)?;
-        let server = get_attr_string(body, "server", env)?
-            .context("foreign_table 'server' is required")?;
+        let server =
+            get_attr_string(body, "server", env)?.context("foreign_table 'server' is required")?;
         let comment = get_attr_string(body, "comment", env)?;
 
         let mut columns = Vec::new();
@@ -1184,7 +1185,10 @@ impl ForEachSupport for AstTextSearchConfiguration {
                 Some(attr) => expr_to_string_vec(attr.expr(), env)?,
                 None => bail!("mapping missing 'with' attribute"),
             };
-            mappings.push(AstTextSearchConfigurationMapping { tokens, dictionaries });
+            mappings.push(AstTextSearchConfigurationMapping {
+                tokens,
+                dictionaries,
+            });
         }
 
         Ok(AstTextSearchConfiguration {
@@ -1239,8 +1243,8 @@ impl ForEachSupport for AstTextSearchParser {
             .context("text_search_parser 'start' is required")?;
         let gettoken = get_attr_string(body, "gettoken", env)?
             .context("text_search_parser 'gettoken' is required")?;
-        let end = get_attr_string(body, "end", env)?
-            .context("text_search_parser 'end' is required")?;
+        let end =
+            get_attr_string(body, "end", env)?.context("text_search_parser 'end' is required")?;
         let headline = get_attr_string(body, "headline", env)?;
         let lextypes = get_attr_string(body, "lextypes", env)?
             .context("text_search_parser 'lextypes' is required")?;
@@ -1286,9 +1290,9 @@ impl ForEachSupport for AstPublication {
                                     let schema = match obj.swap_remove("schema") {
                                         Some(Value::String(s)) => Some(s),
                                         None => None,
-                                        Some(other) => bail!(
-                                            "tables[].schema must be string, got {other:?}"
-                                        ),
+                                        Some(other) => {
+                                            bail!("tables[].schema must be string, got {other:?}")
+                                        }
                                     };
                                     out.push(AstPublicationTable { schema, table });
                                 }

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -1,14 +1,13 @@
 pub mod config;
 
 pub use config::{
-    AggregateSpec, BackReferenceSpec, CheckSpec, ColumnSpec, CompositeTypeFieldSpec,
+    AggregateSpec, BackReferenceSpec, CheckSpec, CollationSpec, ColumnSpec, CompositeTypeFieldSpec,
     CompositeTypeSpec, Config, DomainSpec, EnumSpec, EventTriggerSpec, ExtensionSpec,
-    CollationSpec, OperatorSpec, RuleSpec,
-    ForeignDataWrapperSpec, ForeignKeySpec, ForeignServerSpec, ForeignTableSpec,
-    FunctionSpec, ProcedureSpec, GrantSpec, IndexSpec, MaterializedViewSpec, OutputSpec,
-    PartitionBySpec, PartitionSpec, PolicySpec, PrimaryKeySpec, PublicationSpec,
-    PublicationTableSpec, RoleSpec, TablespaceSpec, SchemaSpec, SequenceSpec, StandaloneIndexSpec,
-    StatisticsSpec, SubscriptionSpec, TableSpec, TestSpec, TextSearchConfigurationMappingSpec,
-    TextSearchConfigurationSpec, TextSearchDictionarySpec, TextSearchParserSpec,
-    TextSearchTemplateSpec, TriggerSpec, ViewSpec,
+    ForeignDataWrapperSpec, ForeignKeySpec, ForeignServerSpec, ForeignTableSpec, FunctionSpec,
+    GrantSpec, IndexSpec, MaterializedViewSpec, OperatorSpec, OutputSpec, PartitionBySpec,
+    PartitionSpec, PolicySpec, PrimaryKeySpec, ProcedureSpec, PublicationSpec,
+    PublicationTableSpec, RoleSpec, RuleSpec, SchemaSpec, SequenceSpec, StandaloneIndexSpec,
+    StatisticsSpec, SubscriptionSpec, TableSpec, TablespaceSpec, TestSpec,
+    TextSearchConfigurationMappingSpec, TextSearchConfigurationSpec, TextSearchDictionarySpec,
+    TextSearchParserSpec, TextSearchTemplateSpec, TriggerSpec, ViewSpec,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,9 +19,10 @@ use std::path::Path;
 // Public re-exports
 use crate::frontend::env::EnvVars;
 pub use ir::{
-    AggregateSpec, CollationSpec, CompositeTypeSpec, Config, DomainSpec, EnumSpec, EventTriggerSpec,
-    ExtensionSpec, FunctionSpec, ProcedureSpec, GrantSpec, MaterializedViewSpec, OutputSpec, PolicySpec,
-    RoleSpec, TablespaceSpec, SchemaSpec, SequenceSpec, TableSpec, TriggerSpec, ViewSpec,
+    AggregateSpec, CollationSpec, CompositeTypeSpec, Config, DomainSpec, EnumSpec,
+    EventTriggerSpec, ExtensionSpec, FunctionSpec, GrantSpec, MaterializedViewSpec, OutputSpec,
+    PolicySpec, ProcedureSpec, RoleSpec, SchemaSpec, SequenceSpec, TableSpec, TablespaceSpec,
+    TriggerSpec, ViewSpec,
 };
 
 // Loader abstraction: lets callers control how files are read.

--- a/src/lint/column_type_mismatch.rs
+++ b/src/lint/column_type_mismatch.rs
@@ -40,7 +40,8 @@ impl LintCheck for ColumnTypeMismatch {
                     else {
                         continue;
                     };
-                    let Some(ref_col) = ref_table.columns.iter().find(|c| &c.name == ref_col_name) else {
+                    let Some(ref_col) = ref_table.columns.iter().find(|c| &c.name == ref_col_name)
+                    else {
                         continue;
                     };
                     let src_ty = src_col
@@ -151,4 +152,3 @@ mod tests {
         assert!(msgs.iter().any(|m| m.check == "column-type-mismatch"));
     }
 }
-

--- a/src/lint/missing_foreign_key_index.rs
+++ b/src/lint/missing_foreign_key_index.rs
@@ -152,4 +152,3 @@ mod tests {
         assert!(msgs.iter().any(|m| m.check == "missing-foreign-key-index"));
     }
 }
-

--- a/src/lint/mod.rs
+++ b/src/lint/mod.rs
@@ -2,19 +2,19 @@ use crate::ir::Config;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+mod column_type_mismatch;
 mod destructive_change;
 mod long_identifier;
-mod column_type_mismatch;
+mod missing_foreign_key_index;
 mod sql_syntax;
 mod unused_index;
-mod missing_foreign_key_index;
 
+use column_type_mismatch::ColumnTypeMismatch;
 use destructive_change::DestructiveChange;
 use long_identifier::LongIdentifier;
-use column_type_mismatch::ColumnTypeMismatch;
+use missing_foreign_key_index::MissingForeignKeyIndex;
 use sql_syntax::SqlSyntax;
 use unused_index::UnusedIndex;
-use missing_foreign_key_index::MissingForeignKeyIndex;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]

--- a/src/postgres/collation.rs
+++ b/src/postgres/collation.rs
@@ -57,7 +57,10 @@ impl fmt::Display for Collation {
                 parts.push(format!("PROVIDER = {}", provider.to_uppercase()));
             }
             if let Some(det) = self.deterministic {
-                parts.push(format!("DETERMINISTIC = {}", if det { "true" } else { "false" }));
+                parts.push(format!(
+                    "DETERMINISTIC = {}",
+                    if det { "true" } else { "false" }
+                ));
             }
             if let Some(version) = &self.version {
                 parts.push(format!("VERSION = {}", literal(version)));

--- a/src/postgres/mod.rs
+++ b/src/postgres/mod.rs
@@ -11,8 +11,7 @@ pub use foreign_data_wrapper::ForeignDataWrapper;
 pub use foreign_server::ForeignServer;
 pub use foreign_table::ForeignTable;
 pub use text_search::{
-    TextSearchConfiguration, TextSearchDictionary, TextSearchParser,
-    TextSearchTemplate,
+    TextSearchConfiguration, TextSearchDictionary, TextSearchParser, TextSearchTemplate,
 };
 
 pub fn ident(s: &str) -> String {
@@ -972,10 +971,7 @@ impl Index {
     pub fn from_specs(table: &crate::ir::TableSpec, idx: &crate::ir::IndexSpec) -> Self {
         Self {
             table_schema: table.schema.clone().unwrap_or_else(|| "public".to_string()),
-            table_name: table
-                .alt_name
-                .clone()
-                .unwrap_or_else(|| table.name.clone()),
+            table_name: table.alt_name.clone().unwrap_or_else(|| table.name.clone()),
             name: idx.name.clone(),
             columns: idx.columns.clone(),
             expressions: idx.expressions.clone(),

--- a/src/postgres/text_search.rs
+++ b/src/postgres/text_search.rs
@@ -23,8 +23,13 @@ impl From<&crate::ir::TextSearchDictionarySpec> for TextSearchDictionary {
 
 impl fmt::Display for TextSearchDictionary {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "CREATE TEXT SEARCH DICTIONARY {}.{} (TEMPLATE = {}",
-               ident(&self.schema), ident(&self.name), self.template)?;
+        write!(
+            f,
+            "CREATE TEXT SEARCH DICTIONARY {}.{} (TEMPLATE = {}",
+            ident(&self.schema),
+            ident(&self.name),
+            self.template
+        )?;
         for opt in &self.options {
             write!(f, ", {opt}")?;
         }
@@ -66,7 +71,8 @@ impl From<&crate::ir::TextSearchConfigurationSpec> for TextSearchConfiguration {
 
 impl fmt::Display for TextSearchConfiguration {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f,
+        write!(
+            f,
             "CREATE TEXT SEARCH CONFIGURATION {}.{} (PARSER = {});",
             ident(&self.schema),
             ident(&self.name),
@@ -107,7 +113,8 @@ impl From<&crate::ir::TextSearchTemplateSpec> for TextSearchTemplate {
 
 impl fmt::Display for TextSearchTemplate {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f,
+        write!(
+            f,
             "CREATE TEXT SEARCH TEMPLATE {}.{} (LEXIZE = {}",
             ident(&self.schema),
             ident(&self.name),

--- a/src/test_runner/mod.rs
+++ b/src/test_runner/mod.rs
@@ -4,6 +4,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::ir::Config;
 
+pub mod pglite;
 pub mod postgres;
 
 pub struct TestResult {

--- a/src/test_runner/pglite.rs
+++ b/src/test_runner/pglite.rs
@@ -1,0 +1,289 @@
+use std::collections::HashSet;
+use std::str;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use anyhow::{anyhow, Context, Result};
+use bytes::BytesMut;
+use fallible_iterator::FallibleIterator;
+use log::info;
+use pglite_oxide::interactive::{self, PokeInput};
+use postgres_protocol::message::backend::{DataRowBody, ErrorResponseBody, Message};
+
+use super::{is_verbose, TestBackend, TestResult, TestSummary};
+use crate::ir::Config;
+
+const RETRY_WAIT: Duration = Duration::from_millis(50);
+const RETRY_TIMEOUT: Duration = Duration::from_secs(5);
+
+pub struct PgliteTestBackend;
+
+impl TestBackend for PgliteTestBackend {
+    fn run(&self, cfg: &Config, dsn: &str, only: Option<&HashSet<String>>) -> Result<TestSummary> {
+        if !dsn.trim().is_empty() {
+            return Err(anyhow!(
+                "pglite backend does not support custom DSN overrides"
+            ));
+        }
+
+        let _mount = pglite_oxide::prepare_default_mount()?;
+        interactive::with_default_runtime(|rt| rt.ensure_handshake())?;
+
+        let mut results = Vec::new();
+        let mut passed = 0usize;
+        for t in &cfg.tests {
+            if let Some(only) = only {
+                if !only.contains(&t.name) {
+                    continue;
+                }
+            }
+
+            let name = t.name.clone();
+            let mut ok = true;
+            let mut failed_msg = String::new();
+            let mut began = false;
+
+            if let Err(err) = exec_statement("BEGIN") {
+                ok = false;
+                failed_msg = format!("failed to begin transaction: {err}");
+            } else {
+                began = true;
+            }
+
+            if ok {
+                for s in &t.setup {
+                    if is_verbose() {
+                        info!("-- setup: {}", s);
+                    }
+                    if let Err(err) = exec_statement(s) {
+                        ok = false;
+                        failed_msg = format!("setup failed: {err}");
+                        break;
+                    }
+                }
+            }
+
+            if ok {
+                for a in &t.asserts {
+                    if is_verbose() {
+                        info!("-- assert: {}", a);
+                    }
+                    match exec_query_bool(a) {
+                        Ok(true) => {}
+                        Ok(false) => {
+                            ok = false;
+                            failed_msg = "assert returned false".into();
+                            break;
+                        }
+                        Err(err) => {
+                            ok = false;
+                            failed_msg = format!("assert error: {err}");
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if ok {
+                for a in &t.assert_fail {
+                    if is_verbose() {
+                        info!("-- assert-fail: {}", a);
+                    }
+                    match exec_expect_error(a) {
+                        Ok(()) => {}
+                        Err(err) => {
+                            ok = false;
+                            failed_msg = format!("assert-fail succeeded unexpectedly: {err}");
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if began {
+                let _ = exec_statement("ROLLBACK");
+            }
+
+            if ok {
+                passed += 1;
+            }
+
+            results.push(TestResult {
+                name,
+                passed: ok,
+                message: if ok { "ok".into() } else { failed_msg },
+            });
+        }
+
+        let total = results.len();
+        let failed = total - passed;
+        Ok(TestSummary {
+            total,
+            passed,
+            failed,
+            results,
+        })
+    }
+}
+
+struct ParsedResponse {
+    error: Option<String>,
+    data_row: Option<Vec<Option<Vec<u8>>>>,
+}
+
+fn exec_statement(sql: &str) -> Result<()> {
+    let response = exec_with_retry(sql)?;
+    if let Some(err) = response.error {
+        Err(anyhow!(err))
+    } else {
+        Ok(())
+    }
+}
+
+fn exec_query_bool(sql: &str) -> Result<bool> {
+    let response = exec_with_retry(sql)?;
+    if let Some(err) = response.error {
+        return Err(anyhow!(err));
+    }
+    let row = response.data_row.unwrap_or_default();
+    let value = row.into_iter().next().unwrap_or(None);
+    decode_bool(value)
+}
+
+fn exec_expect_error(sql: &str) -> Result<()> {
+    let response = exec_with_retry(sql)?;
+    if let Some(_) = response.error {
+        Ok(())
+    } else {
+        Err(anyhow!("statement succeeded unexpectedly"))
+    }
+}
+
+fn exec_with_retry(sql: &str) -> Result<ParsedResponse> {
+    let deadline = Instant::now() + RETRY_TIMEOUT;
+    loop {
+        match exec_sql(sql) {
+            Ok(resp) => return Ok(resp),
+            Err(err) => {
+                if Instant::now() >= deadline {
+                    return Err(err);
+                }
+                thread::sleep(RETRY_WAIT);
+            }
+        }
+    }
+}
+
+fn exec_sql(sql: &str) -> Result<ParsedResponse> {
+    let bytes = interactive::with_default_runtime(|rt| rt.exec_interactive(PokeInput::Str(sql)))
+        .with_context(|| format!("executing '{sql}'"))?;
+    parse_response(&bytes)
+}
+
+fn parse_response(buf: &[u8]) -> Result<ParsedResponse> {
+    let mut bytes = BytesMut::from(buf);
+    let mut error = None;
+    let mut data_row = None;
+
+    while !bytes.is_empty() {
+        match Message::parse(&mut bytes).map_err(|e| anyhow!(e))? {
+            Some(Message::ErrorResponse(body)) => {
+                error = Some(parse_error(body)?);
+            }
+            Some(Message::DataRow(body)) => {
+                if data_row.is_none() {
+                    data_row = Some(parse_data_row(body)?);
+                }
+            }
+            Some(Message::ReadyForQuery(_)) => break,
+            Some(_) => {}
+            None => break,
+        }
+    }
+
+    Ok(ParsedResponse { error, data_row })
+}
+
+fn parse_error(body: ErrorResponseBody) -> Result<String> {
+    let mut fields = body.fields();
+    let mut message = String::from("unknown error");
+    while let Some(field) = fields.next()? {
+        if field.type_() == b'M' {
+            message = str::from_utf8(field.value_bytes())
+                .unwrap_or("unknown error")
+                .to_string();
+        }
+    }
+    Ok(message)
+}
+
+fn parse_data_row(body: DataRowBody) -> Result<Vec<Option<Vec<u8>>>> {
+    let mut values = Vec::new();
+    let buffer = body.buffer();
+    let mut ranges = body.ranges();
+    while let Some(range) = ranges.next()? {
+        match range {
+            Some(range) => values.push(Some(buffer[range.start..range.end].to_vec())),
+            None => values.push(None),
+        }
+    }
+    Ok(values)
+}
+
+fn decode_bool(field: Option<Vec<u8>>) -> Result<bool> {
+    match field {
+        None => Ok(false),
+        Some(bytes) => {
+            if bytes.is_empty() {
+                return Ok(false);
+            }
+            if bytes == b"t" || bytes.eq_ignore_ascii_case(b"true") {
+                return Ok(true);
+            }
+            if bytes == b"f" || bytes.eq_ignore_ascii_case(b"false") {
+                return Ok(false);
+            }
+            if let Ok(text) = str::from_utf8(&bytes) {
+                if let Ok(i) = text.trim().parse::<i64>() {
+                    return Ok(i != 0);
+                }
+            }
+            Err(anyhow!("unsupported assert result type"))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PgliteTestBackend;
+    use crate::ir::{Config, TestSpec};
+    use crate::test_runner::TestBackend;
+
+    #[test]
+    fn runs_simple_test() {
+        let backend = PgliteTestBackend;
+        let config = Config {
+            tests: vec![TestSpec {
+                name: "basic-select".into(),
+                setup: vec![
+                    "CREATE TABLE numbers(value INTEGER);".into(),
+                    "INSERT INTO numbers VALUES (1);".into(),
+                ],
+                asserts: vec![
+                    "SELECT COUNT(*) = 1 FROM numbers".into(),
+                    "SELECT value = 1 FROM numbers LIMIT 1".into(),
+                ],
+                assert_fail: vec!["INSERT INTO numbers(value) VALUES (1/0);".into()],
+                teardown: Vec::new(),
+            }],
+            ..Config::default()
+        };
+
+        let summary = backend
+            .run(&config, "", None)
+            .expect("pglite backend should run");
+        assert_eq!(summary.total, 1);
+        assert_eq!(summary.passed, 1);
+        assert_eq!(summary.failed, 0);
+    }
+}


### PR DESCRIPTION
## Summary
- add a synchronous pglite-backed test runner that talks directly to the interactive API
- parse responses using postgres-protocol helpers and reuse generic boolean decoding
- add a regression test that exercises the backend and adjust dependencies for the new code

## Testing
- cargo check 2>&1 | cat
- cargo test pglite -- --nocapture

------
https://chatgpt.com/codex/tasks/task_e_68d92f11c3d88331b51ab32ee175d6af