### PR TITLE
feat: document built-in functions

### DIFF
--- a/docs/variables.md
+++ b/docs/variables.md
@@ -92,3 +92,23 @@ table "users" {
   }
 }
 ```
+
+## Functions
+
+Expressions may call a number of built‑in helpers. These are grouped
+roughly by category:
+
+* **String**: `upper`, `lower`, `length`, `substr`, `contains`,
+  `startswith`, `endswith`, `trim`, `replace`
+* **Numeric**: `min`, `max`, `abs`
+* **Collections**: `concat`, `flatten`, `distinct`, `slice`, `sort`,
+  `reverse`, `index`
+* **Utility**: `coalesce`, `join`, `split`
+* **Conversion**: `tostring`, `tonumber`, `tobool`, `tolist`, `tomap`
+* **Crypto/Base64**: `md5`, `sha256`, `sha512`, `base64encode`,
+  `base64decode`
+* **Datetime**: `timestamp`, `formatdate`, `timeadd`, `timecmp`
+
+These functions mirror those available in Terraform's expression
+language and can be used anywhere an expression is accepted, including
+within variable defaults and locals.


### PR DESCRIPTION
## Summary
- document available expression helpers in variables guide

## Testing
- `cargo check 2>&1 | cat`


------
https://chatgpt.com/codex/tasks/task_e_68c485cf00a8833188bd624777a4c731