### PR TITLE
Fix resource filtering coverage and defaults

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -851,6 +851,8 @@ mod tests {
             ..Default::default()
         };
 
+        use crate::config::ResourceKind;
+
         let include_all = ResourceKind::default_include_set();
         let filtered = apply_filters(&cfg, &include_all, &HashSet::new());
         assert_eq!(filtered.indexes.len(), 1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,7 +118,6 @@ enum Commands {
         #[arg(long)]
         verbose: bool,
     },
-
 }
 
 fn main() -> Result<()> {
@@ -417,12 +416,12 @@ fn main() -> Result<()> {
                                 .batch_execute(&artifact)
                                 .with_context(|| "applying generated migration to database")?;
                         }
-
                     }
                 }
 
                 dbschema::test_runner::set_verbose(verbose);
-                let runner: Box<dyn TestBackend> = Box::new(dbschema::test_runner::postgres::PostgresTestBackend);
+                let runner: Box<dyn TestBackend> =
+                    Box::new(dbschema::test_runner::postgres::PostgresTestBackend);
                 let only: Option<std::collections::HashSet<String>> = if names.is_empty() {
                     None
                 } else {
@@ -469,7 +468,6 @@ fn main() -> Result<()> {
                     }
                 }
             }
-
         }
     }
 
@@ -538,8 +536,8 @@ fn run_target(dbschema_config: &DbschemaConfig, target: &TargetConfig, strict: b
     let config = load_config(&PathBuf::from(input_path), &fs_loader, env.clone())
         .with_context(|| format!("loading root HCL from {}", input_path))?;
 
-    let include_set = target.get_include_set();
-    let exclude_set = target.get_exclude_set();
+    let include_set = target.get_include_set()?;
+    let exclude_set = target.get_exclude_set()?;
 
     let filtered = apply_filters(&config, &include_set, &exclude_set);
 
@@ -685,24 +683,7 @@ fn cli_filter_sets(
     use ResourceKind as R;
 
     let mut include_set: HashSet<R> = if include.is_empty() {
-        [
-            R::Schemas,
-            R::Enums,
-            R::Domains,
-            R::Types,
-            R::Tables,
-            R::Views,
-            R::Materialized,
-            R::Functions,
-            R::Triggers,
-            R::Extensions,
-            R::Collations,
-            R::Sequences,
-            R::Policies,
-            R::Tests,
-        ]
-        .into_iter()
-        .collect()
+        ResourceKind::default_include_set()
     } else {
         include.iter().copied().collect()
     };


### PR DESCRIPTION
## Summary
- extend `ResourceKind` to cover indexes, statistics, foreign data, and text search resources, and share a single default include set
- surface invalid resource names in target configs and reuse the shared defaults in the CLI include handling
- keep `apply_filters` from dropping supported resources and add regression tests for the expanded filtering

## Testing
- cargo check 2>&1 | cat

------
https://chatgpt.com/codex/tasks/task_e_68e3aa9305d48331ba64462a81bf616c